### PR TITLE
Get readthedocs to install this package for autodoc

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,3 +22,5 @@ python:
   version: 3.7
   install:
     - requirements: docs/requirements.txt
+    - method: pip
+      path: .


### PR DESCRIPTION
I think autodoc is failing on readthedocs because the Snakebids' external dependencies aren't being installed -- I think this small configuration change should resolve that (I don't know if there's a good way to test it without pulling the change first, though).