### PR TITLE
fix: was using a non-existant help_snakemake arg

### DIFF
--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -223,9 +223,6 @@ class SnakeBidsApp:
         args = all_args[0]
         snakemake_args = all_args[1]
 
-        if args.help_snakemake:
-            print(self.parser_include_snakemake.print_help())
-
         # add arguments to config
         self.config.update(args.__dict__)
         self.config.update({'snakemake_args': snakemake_args})


### PR DESCRIPTION
this is probably a bug I introduced when I was playing around with different argparse set-ups, but was causing a failure once you get past the usage