### PR TITLE
Run black -l 79 on project, and add GH action to lint with black

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,13 @@
+name: Lint
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: psf/black@master
+        with:
+          args: "--check -l 79"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,16 +12,17 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../'))
+
+sys.path.insert(0, os.path.abspath("../"))
 import sphinx_rtd_theme
 
 
 # -- Project information -----------------------------------------------------
 
 
-project = 'snakebids'
-copyright = '2020, Ali R. Khan'
-author = 'Ali R. Khan'
+project = "snakebids"
+copyright = "2020, Ali R. Khan"
+author = "Ali R. Khan"
 
 
 # -- General configuration ---------------------------------------------------
@@ -33,7 +34,7 @@ extensions = [
     "sphinx_rtd_theme",
     "sphinxarg.ext",
     "sphinx.ext.autodoc",
-    "sphinxcontrib.napoleon"
+    "sphinxcontrib.napoleon",
 ]
 
 napoleon_google_docstring = False
@@ -41,15 +42,15 @@ napoleon_numpy_docstring = True
 
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
-master_doc = 'index'
+master_doc = "index"
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -62,8 +63,4 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
-
-
-
-
+html_static_path = ["_static"]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.rst", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="snakebids", 
+    name="snakebids",
     version="0.3.0",
     author="Ali Khan",
     author_email="alik@robarts.ca",
@@ -24,5 +24,5 @@ setuptools.setup(
         "snakemake>=5.28.0",
         "PyYAML>=5.3.1",
     ],
-    python_requires='>=3.7'
+    python_requires=">=3.7",
 )

--- a/snakebids/__init__.py
+++ b/snakebids/__init__.py
@@ -11,7 +11,7 @@ import bids
 
 from snakebids.snakemake_io import glob_wildcards
 
-bids.config.set_option('extension_initial_dot', True)
+bids.config.set_option("extension_initial_dot", True)
 
 
 # pylint: disable=function-redefined, too-many-arguments
@@ -24,7 +24,7 @@ def bids(
     session=None,
     include_subject_dir=True,
     include_session_dir=True,
-    **entities
+    **entities,
 ):
     """Helper function for generating bids paths for snakemake workflows.
 
@@ -139,23 +139,27 @@ def bids(
 
     # replace underscores in keys (needed to that users can use reserved
     # keywords by appending a _)
-    entities = {k.replace('_', ''): v for k, v in entities.items()}
+    entities = {k.replace("_", ""): v for k, v in entities.items()}
 
     # strict ordering of bids entities is specified here:
-    order = OrderedDict([('task', None),
-                         ('acq', None),
-                         ('ce', None),
-                         ('rec', None),
-                         ('dir', None),
-                         ('run', None),
-                         ('mod', None),
-                         ('echo', None),
-                         ('hemi', None),
-                         ('space', None),
-                         ('res', None),
-                         ('den', None),
-                         ('label', None),
-                         ('desc', None)])
+    order = OrderedDict(
+        [
+            ("task", None),
+            ("acq", None),
+            ("ce", None),
+            ("rec", None),
+            ("dir", None),
+            ("run", None),
+            ("mod", None),
+            ("echo", None),
+            ("hemi", None),
+            ("space", None),
+            ("res", None),
+            ("den", None),
+            ("label", None),
+            ("desc", None),
+        ]
+    )
 
     # Now add in entities (this preserves ordering above)
     for key, val in entities.items():
@@ -177,21 +181,21 @@ def bids(
     # if subject defined then append to file and folder
     if isinstance(subject, str):
         if include_subject_dir is True:
-            folder.append(f'sub-{subject}')
-        filename.append(f'sub-{subject}')
+            folder.append(f"sub-{subject}")
+        filename.append(f"sub-{subject}")
 
     # if session defined then append to file and folder
     if isinstance(session, str):
         if include_session_dir is True:
-            folder.append(f'ses-{session}')
-        filename.append(f'ses-{session}')
+            folder.append(f"ses-{session}")
+        filename.append(f"ses-{session}")
 
     if isinstance(datatype, str):
         folder.append(datatype)
 
     # add the entities
     filename += [
-        f'{key}-{val}' for key, val in order.items() if val is not None
+        f"{key}-{val}" for key, val in order.items() if val is not None
     ]
 
     # if suffix is defined, append it
@@ -199,10 +203,10 @@ def bids(
         filename.append(suffix)
 
     if len(filename) == 0:
-        return ''
+        return ""
 
     # now, join up the lists:
-    filename = '_'.join(filename)
+    filename = "_".join(filename)
 
     if len(folder) > 0:
         filename = join(*folder, filename)
@@ -211,10 +215,11 @@ def bids(
 
 
 def print_boilerplate():
-    """ Function to print out boilerplate to add to Snakefile. (not used
+    """Function to print out boilerplate to add to Snakefile. (not used
     anywhere yet)"""
 
-    print('''
+    print(
+        """
 # ---- begin snakebids boilerplate ------------------------------------------
 
 import snakebids
@@ -236,11 +241,12 @@ wildcard_constraints:  **snakebids.get_wildcard_constraints(
 )
 
 # ---- end snakebids boilerplate --------------------------------------------
-''')
+"""
+    )
 
 
 def filter_list(zip_list, wildcards, return_indices_only=False):
-    """ This function is used when you are expanding over some subset of the
+    """This function is used when you are expanding over some subset of the
     wildcards i.e. if your output file doesn't contain all the wildcards in
     input_wildcards
 
@@ -441,9 +447,7 @@ def get_filtered_ziplist_index(zip_list, wildcards, subj_wildcards):
 
     # get the index of the wildcard from this filtered list
     indices = filter_list(
-        zip_list_filtered,
-        wildcards,
-        return_indices_only=True
+        zip_list_filtered, wildcards, return_indices_only=True
     )
     if len(indices) == 1:
         return indices[0]
@@ -451,7 +455,7 @@ def get_filtered_ziplist_index(zip_list, wildcards, subj_wildcards):
 
 
 def __read_bids_tags(bids_json=None):
-    """ Read the bids tags we are aware of from a JSON file. This is used
+    """Read the bids tags we are aware of from a JSON file. This is used
     specifically for compatibility with pybids, since some tag keys are
     different from how they appear in the file name, e.g. ``subject`` for
     ``sub``, and ``acquisition`` for ``acq``.
@@ -465,14 +469,12 @@ def __read_bids_tags(bids_json=None):
     Returns
     -------
     dict:
-        Dictionary of bids tags
-"""
+        Dictionary of bids tags"""
     if bids_json is None:
         bids_json = os.path.join(
-            os.path.dirname(os.path.realpath(__file__)),
-            'bids_tags.json'
+            os.path.dirname(os.path.realpath(__file__)), "bids_tags.json"
         )
-    with open(bids_json, 'r') as infile:
+    with open(bids_json, "r") as infile:
         bids_tags = json.load(infile)
     return bids_tags
 
@@ -484,9 +486,9 @@ def generate_inputs(
     search_terms=None,
     limit_to=None,
     participant_label=None,
-    exclude_participant_label=None
+    exclude_participant_label=None,
 ):
-    """ Dynamically generate snakemake inputs using pybids_inputs dict, and
+    """Dynamically generate snakemake inputs using pybids_inputs dict, and
     pybids to parse the bids dataset.
 
     Parameters
@@ -526,8 +528,8 @@ def generate_inputs(
 
     if participant_label is not None and exclude_participant_label is not None:
         print(
-            'ERROR: cannot define both participant_label and '
-            'exclude_participant_label at the same time'
+            "ERROR: cannot define both participant_label and "
+            "exclude_participant_label at the same time"
         )
         return None
 
@@ -537,20 +539,20 @@ def generate_inputs(
     # participant_label and exclude_participant_label defined
     if participant_label is not None:
         if isinstance(participant_label, list):
-            search_terms['subject'] = participant_label
+            search_terms["subject"] = participant_label
         else:
-            search_terms['subject'] = [participant_label]
+            search_terms["subject"] = [participant_label]
 
     if exclude_participant_label is not None:
         # if multiple subjects to exclude, combine with with subj1|subj2|...
         if isinstance(exclude_participant_label, list):
-            exclude_string = '|'.join(exclude_participant_label)
+            exclude_string = "|".join(exclude_participant_label)
         # if not, then string is the label itself
         else:
             exclude_string = exclude_participant_label
-        search_terms['regex_search'] = True
+        search_terms["regex_search"] = True
         # regex to exclude subjects
-        search_terms['subject'] = [f'^((?!({exclude_string})).)*$']
+        search_terms["subject"] = [f"^((?!({exclude_string})).)*$"]
 
     if os.path.exists(bids_dir):
         # generate inputs based on config
@@ -558,15 +560,12 @@ def generate_inputs(
             bids_dir,
             derivatives=derivatives,
             validate=False,
-            indexer=BIDSLayoutIndexer(
-                validate=False,
-                index_metadata=False
-            )
+            indexer=BIDSLayoutIndexer(validate=False, index_metadata=False),
         )
     else:
         print(
-            'WARNING: bids_dir does not exist, skipping PyBIDS and using '
-            'custom file paths only'
+            "WARNING: bids_dir does not exist, skipping PyBIDS and using "
+            "custom file paths only"
         )
         layout = None
 
@@ -576,55 +575,50 @@ def generate_inputs(
         bids_layout=layout,
         pybids_inputs=pybids_inputs,
         limit_to=limit_to,
-        **search_terms
+        **search_terms,
     )
 
     if layout is None:
         # if no layout, then use subjects/sessions from --path vars
         subjects = list()
         sessions = list()
-        for input_type in inputs_config_dict['input_lists']:
+        for input_type in inputs_config_dict["input_lists"]:
             subjects.append(
-                 set(
-                     inputs_config_dict['input_lists'][input_type]['subject']
-                 )
+                set(inputs_config_dict["input_lists"][input_type]["subject"])
             )
-            if 'session' in (
-                inputs_config_dict['input_lists'][input_type].keys()
+            if "session" in (
+                inputs_config_dict["input_lists"][input_type].keys()
             ):
                 sessions.append(
-                    {inputs_config_dict['input_lists'][input_type]['session']}
+                    {inputs_config_dict["input_lists"][input_type]["session"]}
                 )
             else:
                 sessions.append(set([]))
 
         # take set intersection of all input types
-        inputs_config_dict['subjects'] = list(set.intersection(*subjects))
-        inputs_config_dict['sessions'] = list(set.intersection(*sessions))
+        inputs_config_dict["subjects"] = list(set.intersection(*subjects))
+        inputs_config_dict["sessions"] = list(set.intersection(*sessions))
 
     else:
         # populate subjects, sessions and subj_wildcards in the config
-        inputs_config_dict['subjects'] = layout.get_subjects(**search_terms)
-        inputs_config_dict['sessions'] = layout.get_sessions(**search_terms)
+        inputs_config_dict["subjects"] = layout.get_subjects(**search_terms)
+        inputs_config_dict["sessions"] = layout.get_sessions(**search_terms)
 
-    if len(inputs_config_dict['sessions']) == 0:
-        inputs_config_dict['subj_wildcards'] = {'subject': '{subject}'}
+    if len(inputs_config_dict["sessions"]) == 0:
+        inputs_config_dict["subj_wildcards"] = {"subject": "{subject}"}
     else:
-        inputs_config_dict['subj_wildcards'] = {
-            'subject': '{subject}',
-            'session': '{session}'
+        inputs_config_dict["subj_wildcards"] = {
+            "subject": "{subject}",
+            "session": "{session}",
         }
 
     return inputs_config_dict
 
 
 def __get_lists_from_bids(
-    bids_layout,
-    pybids_inputs,
-    limit_to=None,
-    **filters
+    bids_layout, pybids_inputs, limit_to=None, **filters
 ):
-    """ Grabs files using pybids and creates snakemake-friendly lists
+    """Grabs files using pybids and creates snakemake-friendly lists
 
     Parameters
     ----------
@@ -653,10 +647,10 @@ def __get_lists_from_bids(
 
     out_dict = dict(
         {
-            'input_path': {},
-            'input_zip_lists': {},
-            'input_lists': {},
-            'input_wildcards': {}
+            "input_path": {},
+            "input_zip_lists": {},
+            "input_lists": {},
+            "input_wildcards": {},
         }
     )
 
@@ -666,42 +660,41 @@ def __get_lists_from_bids(
         inputs_to_iterate = limit_to
 
     for input_name in inputs_to_iterate:
-        if 'custom_path' in pybids_inputs[input_name].keys():
+        if "custom_path" in pybids_inputs[input_name].keys():
             # a custom path was specified for this input, skip pybids:
             # get input_wildcards by parsing path for {} entries (using a set
             # to get unique only)
             # get input_zip_lists by using glob_wildcards (but need to modify
             # to deal with multiple wildcards
 
-            input_path = pybids_inputs[input_name]['custom_path']
+            input_path = pybids_inputs[input_name]["custom_path"]
             wildcards = glob_wildcards(input_path)
             wildcard_names = list(wildcards._fields)
             if len(wildcard_names) == 0:
-                print(f'WARNING: no wildcards defined in {input_path}')
+                print(f"WARNING: no wildcards defined in {input_path}")
             input_wildcards = {}
             input_zip_lists = {}
             input_lists = {}
             for i, wildcard in enumerate(wildcard_names):
                 input_zip_lists[wildcard] = wildcards[i]
                 input_lists[wildcard] = list(set(wildcards[i]))
-                input_wildcards[wildcard] = f'{{{wildcard}}}'
+                input_wildcards[wildcard] = f"{{{wildcard}}}"
                 if len(wildcards[i]) == 0:
-                    print(f'ERROR: No matching files for {input_path}')
+                    print(f"ERROR: No matching files for {input_path}")
 
-            out_dict['input_path'][input_name] = input_path
-            out_dict['input_zip_lists'][input_name] = input_zip_lists
-            out_dict['input_lists'][input_name] = input_lists
-            out_dict['input_wildcards'][input_name] = input_wildcards
+            out_dict["input_path"][input_name] = input_path
+            out_dict["input_zip_lists"][input_name] = input_zip_lists
+            out_dict["input_lists"][input_name] = input_lists
+            out_dict["input_wildcards"][input_name] = input_wildcards
 
         else:
-            imgs, = [
+            (imgs,) = [
                 bids_layout.get(
-                    **pybids_inputs[input_name]['filters'],
-                    **filters
+                    **pybids_inputs[input_name]["filters"], **filters
                 )
             ]
             if len(imgs) == 0:
-                print(f'WARNING: no images found for {input_name}')
+                print(f"WARNING: no images found for {input_name}")
                 continue
 
             paths = set()
@@ -710,7 +703,7 @@ def __get_lists_from_bids(
             wildcards = {}
             for img in imgs:
                 path = img.path
-                for wildcard_name in pybids_inputs[input_name]['wildcards']:
+                for wildcard_name in pybids_inputs[input_name]["wildcards"]:
 
                     if wildcard_name in bids_tags:
                         tag = bids_tags[wildcard_name]
@@ -727,7 +720,7 @@ def __get_lists_from_bids(
                         # bids_tags.json, where e.g. acquisition -> acq is
                         # defined.. -- then, can use wildcard_name instead
                         # of out_name..
-                        if wildcard_name not in ['subject', 'session']:
+                        if wildcard_name not in ["subject", "session"]:
                             out_name = tag
                         else:
                             out_name = wildcard_name
@@ -737,10 +730,9 @@ def __get_lists_from_bids(
                             input_lists[out_name] = set()
                             wildcards[out_name] = {}
 
-                        pattern = '{tag}-([a-zA-Z0-9]+)'.format(tag=tag)
-                        replace = '{tag}-{{{replace}}}'.format(
-                            tag=tag,
-                            replace=out_name
+                        pattern = "{tag}-([a-zA-Z0-9]+)".format(tag=tag)
+                        replace = "{tag}-{{{replace}}}".format(
+                            tag=tag, replace=out_name
                         )
                         match = re.search(pattern, path)
                         replaced = re.sub(pattern, replace, path)
@@ -751,19 +743,19 @@ def __get_lists_from_bids(
                         path = replaced
                         zip_lists[out_name].append(match[1])
                         input_lists[out_name].add(match[1])
-                        wildcards[out_name] = f'{{{out_name}}}'
+                        wildcards[out_name] = f"{{{out_name}}}"
 
                 paths.add(path)
 
             # now, check to see if unique
             if len(paths) > 1:
                 print(
-                    'WARNING: more than one snakemake filename for '
-                    f'{input_name}, taking the first'
+                    "WARNING: more than one snakemake filename for "
+                    f"{input_name}, taking the first"
                 )
                 print(
-                    f'  To correct this, use the --filter_{input_name} '
-                    'option to narrow the search'
+                    f"  To correct this, use the --filter_{input_name} "
+                    "option to narrow the search"
                 )
                 print(paths)
 
@@ -773,16 +765,16 @@ def __get_lists_from_bids(
             for key, val in input_lists.items():
                 input_lists[key] = list(val)
 
-            out_dict['input_path'][input_name] = in_path
-            out_dict['input_zip_lists'][input_name] = zip_lists
-            out_dict['input_lists'][input_name] = input_lists
-            out_dict['input_wildcards'][input_name] = wildcards
+            out_dict["input_path"][input_name] = in_path
+            out_dict["input_zip_lists"][input_name] = zip_lists
+            out_dict["input_lists"][input_name] = input_lists
+            out_dict["input_wildcards"][input_name] = wildcards
 
     return out_dict
 
 
 def get_wildcard_constraints(image_types):
-    """ Return a wildcard_constraints dict for snakemake to use, containing
+    """Return a wildcard_constraints dict for snakemake to use, containing
     all the wildcards that are in the dynamically grabbed inputs
 
     Parameters
@@ -795,7 +787,7 @@ def get_wildcard_constraints(image_types):
         inputs, with typical bids naming constraints, ie letters and numbers
         ``[a-zA-Z0-9]+``.
     """
-    bids_constraints = '[a-zA-Z0-9]+'
+    bids_constraints = "[a-zA-Z0-9]+"
     return {
         entity: bids_constraints
         for imgtype in image_types.keys()
@@ -804,7 +796,7 @@ def get_wildcard_constraints(image_types):
 
 
 def write_derivative_json(snakemake, **kwargs):
-    """ Snakemake function to read a json file, and write to a new one,
+    """Snakemake function to read a json file, and write to a new one,
     adding BIDS derivatives fields for Sources and Parameters.
 
     Parameters
@@ -816,16 +808,16 @@ def write_derivative_json(snakemake, **kwargs):
         it will read and write json files
     """
 
-    with open(snakemake.input.json, 'r') as input_json:
+    with open(snakemake.input.json, "r") as input_json:
         sidecar = json.load(input_json)
 
     sidecar.update(
         {
-            'Sources': [snakemake.input],
-            'Parameters': snakemake.params,
-            **kwargs
+            "Sources": [snakemake.input],
+            "Parameters": snakemake.params,
+            **kwargs,
         }
     )
 
-    with open(snakemake.output.json, 'w') as outfile:
+    with open(snakemake.output.json, "w") as outfile:
         json.dump(sidecar, outfile, indent=4)

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -11,30 +11,25 @@ import yaml
 import bids
 from snakemake import get_argument_parser
 
-bids.config.set_option('extension_initial_dot', True)
+bids.config.set_option("extension_initial_dot", True)
 
 
 class KeyValue(argparse.Action):
     """Class for accepting key=value pairs in argparse"""
+
     # Constructor calling
-    def __call__(
-        self,
-        parser,
-        namespace,
-        values,
-        option_string=None
-    ):
+    def __call__(self, parser, namespace, values, option_string=None):
         setattr(namespace, self.dest, dict())
 
         for value in values:
             # split it into key and value
-            key, value = value.split('=')
+            key, value = value.split("=")
             # assign into dictionary
             getattr(namespace, self.dest)[key] = value
 
 
 def run(command, env=None):
-    """ Helper function for running a system command while merging
+    """Helper function for running a system command while merging
     stderr/stdout to stdout.
 
     Parameters
@@ -50,14 +45,18 @@ def run(command, env=None):
 
     merged_env = os.environ
     merged_env.update(env)
-    process = subprocess.Popen(command, stdout=subprocess.PIPE,
-                               stderr=subprocess.STDOUT, shell=True,
-                               env=merged_env)
+    process = subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        shell=True,
+        env=merged_env,
+    )
     while True:
         line = process.stdout.readline()
-        line = str(line, 'utf-8')[:-1]
+        line = str(line, "utf-8")[:-1]
         print(line)
-        if line == '' and process.poll() is not None:
+        if line == "" and process.poll() is not None:
             break
     if process.returncode != 0:
         raise Exception("Non zero return code: %d" % process.returncode)
@@ -71,14 +70,11 @@ SNAKEFILE_CHOICES = [
 ]
 
 
-CONFIGFILE_CHOICES = [
-    "config/snakebids.yml",
-    "snakebids.yml"
-]
+CONFIGFILE_CHOICES = ["config/snakebids.yml", "snakebids.yml"]
 
 
 class SnakeBidsApp:
-    """ Class for a snakebids app
+    """Class for a snakebids app
     to do: add docs
     """
 
@@ -94,8 +90,7 @@ class SnakeBidsApp:
         for config_path in CONFIGFILE_CHOICES:
             if os.path.exists(os.path.join(snakemake_dir, config_path)):
                 self.snakebids_config = os.path.join(
-                    snakemake_dir,
-                    config_path
+                    snakemake_dir, config_path
                 )
                 break
         if self.snakebids_config is None:
@@ -103,7 +98,7 @@ class SnakeBidsApp:
                 "Error: no snakebids.yml config file found, tried {}.".format(
                     ", ".join(SNAKEFILE_CHOICES)
                 ),
-                file=sys.stderr
+                file=sys.stderr,
             )
             sys.exit(1)
 
@@ -118,7 +113,7 @@ class SnakeBidsApp:
                 "Error: no Snakefile found, tried {}.".format(
                     ", ".join(SNAKEFILE_CHOICES)
                 ),
-                file=sys.stderr
+                file=sys.stderr,
             )
             sys.exit(1)
 
@@ -126,7 +121,7 @@ class SnakeBidsApp:
 
         # add path to snakefile to the config -- so workflows can grab files
         # relative to the snakefile folder
-        self.config['snakemake_dir'] = snakemake_dir
+        self.config["snakemake_dir"] = snakemake_dir
         self.updated_config = []
 
         self.parser_include_snakemake = self.__create_parser(
@@ -139,7 +134,7 @@ class SnakeBidsApp:
 
     def __load_config(self):
         # load up workflow config file
-        with open(self.snakebids_config, 'r') as infile:
+        with open(self.snakebids_config, "r") as infile:
             self.config = yaml.load(infile, Loader=yaml.FullLoader)
 
     def __create_parser(self, include_snakemake=False):
@@ -155,60 +150,61 @@ class SnakeBidsApp:
 
             # create parser
             parser = argparse.ArgumentParser(
-                description='Snakebids helps build BIDS Apps with Snakemake',
+                description="Snakebids helps build BIDS Apps with Snakemake",
                 add_help=False,
-                parents=[smk_parser]
+                parents=[smk_parser],
             )
         else:
             parser = argparse.ArgumentParser(
-                description='Snakebids helps build BIDS Apps with Snakemake'
+                description="Snakebids helps build BIDS Apps with Snakemake"
             )
 
         # create parser group for app options
         app_group = parser.add_argument_group(
-            'SNAKEBIDS',
-            'Options for snakebids app'
+            "SNAKEBIDS", "Options for snakebids app"
         )
 
         # update the parser with config options
-        for name, parse_args in self.config['parse_args'].items():
+        for name, parse_args in self.config["parse_args"].items():
             app_group.add_argument(name, **parse_args)
 
         # general parser for
         # --filter_{input_type} {key1}={value1} {key2}={value2}...
         # create filter parsers, one for each input_type
         filter_opts = parser.add_argument_group(
-            'BIDS FILTERS',
-            'Filters to customize PyBIDS get() as key=value pairs'
+            "BIDS FILTERS",
+            "Filters to customize PyBIDS get() as key=value pairs",
         )
 
-        for input_type in self.config['pybids_inputs'].keys():
-            argname = f'--filter_{input_type}'
+        for input_type in self.config["pybids_inputs"].keys():
+            argname = f"--filter_{input_type}"
             arglist_default = [
-                f'{key}={value}' for (key, value) in
-                self.config['pybids_inputs'][input_type]['filters'].items()
+                f"{key}={value}"
+                for (key, value) in self.config["pybids_inputs"][input_type][
+                    "filters"
+                ].items()
             ]
-            arglist_default_string = ' '.join(arglist_default)
+            arglist_default_string = " ".join(arglist_default)
 
             filter_opts.add_argument(
                 argname,
-                nargs='+',
+                nargs="+",
                 action=KeyValue,
-                help=f'(default: {arglist_default_string})'
+                help=f"(default: {arglist_default_string})",
             )
 
         override_opts = parser.add_argument_group(
-            'PATH OVERRIDE',
+            "PATH OVERRIDE",
             (
-                'Options for overriding BIDS by specifying absolute paths '
-                'that include wildcards, e.g.: '
-                '/path/to/my_data/{subject}/t1.nii.gz'
+                "Options for overriding BIDS by specifying absolute paths "
+                "that include wildcards, e.g.: "
+                "/path/to/my_data/{subject}/t1.nii.gz"
             ),
         )
 
         # create path override parser
-        for input_type in self.config['pybids_inputs'].keys():
-            argname = f'--path_{input_type}'
+        for input_type in self.config["pybids_inputs"].keys():
+            argname = f"--path_{input_type}"
             override_opts.add_argument(argname, default=None)
 
         return parser
@@ -228,44 +224,42 @@ class SnakeBidsApp:
 
         # add arguments to config
         self.config.update(args.__dict__)
-        self.config.update({'snakemake_args': snakemake_args})
+        self.config.update({"snakemake_args": snakemake_args})
 
         # argparse adds filter_{input_type} to the config
         # we want to update the pybids_inputs dict with this, then remove the
         # filter_{input_type} dict
-        for input_type in self.config['pybids_inputs'].keys():
-            arg_filter_dict = self.config[f'filter_{input_type}']
+        for input_type in self.config["pybids_inputs"].keys():
+            arg_filter_dict = self.config[f"filter_{input_type}"]
             if arg_filter_dict is not None:
-                self.config['pybids_inputs'][input_type]['filters'].update(
+                self.config["pybids_inputs"][input_type]["filters"].update(
                     arg_filter_dict
                 )
-            del self.config[f'filter_{input_type}']
+            del self.config[f"filter_{input_type}"]
 
         # add custom input paths to
         # config['pybids_inputs'][input_type]['custom_path']
-        for input_type in self.config['pybids_inputs'].keys():
-            custom_path = self.config[f'path_{input_type}']
+        for input_type in self.config["pybids_inputs"].keys():
+            custom_path = self.config[f"path_{input_type}"]
             if custom_path is not None:
-                self.config['pybids_inputs'][input_type][
-                    'custom_path'
+                self.config["pybids_inputs"][input_type][
+                    "custom_path"
                 ] = os.path.realpath(custom_path)
-            del self.config[f'path_{input_type}']
+            del self.config[f"path_{input_type}"]
 
         # replace paths with realpaths
-        self.config['bids_dir'] = os.path.realpath(self.config['bids_dir'])
-        self.config['output_dir'] = os.path.realpath(self.config['output_dir'])
+        self.config["bids_dir"] = os.path.realpath(self.config["bids_dir"])
+        self.config["output_dir"] = os.path.realpath(self.config["output_dir"])
 
     def write_updated_config(self):
         """Create an updated snakebids config file in the output dir."""
         self.updated_config = os.path.join(
-            self.config['output_dir'],
-            'config',
-            'snakebids.yml'
+            self.config["output_dir"], "config", "snakebids.yml"
         )
 
         # write it to file
         os.makedirs(os.path.dirname(self.updated_config), exist_ok=True)
-        with open(self.updated_config, 'w') as outfile:
+        with open(self.updated_config, "w") as outfile:
             yaml.dump(self.config, outfile, default_flow_style=False)
 
     def run_snakemake(self):
@@ -280,19 +274,19 @@ class SnakeBidsApp:
 
         # running the chosen participant level
 
-        analysis_level = self.config['analysis_level']
+        analysis_level = self.config["analysis_level"]
         # runs snakemake, using the workflow config and inputs config to
         # override
 
         # run snakemake command-line (passing any leftover args from argparse)
         snakemake_cmd_list = [
-            'snakemake',
-            f'--snakefile {self.snakefile}',
+            "snakemake",
+            f"--snakefile {self.snakefile}",
             f"--directory {self.config['output_dir']}",
-            f'--configfile {self.updated_config} ',
-            *self.config['snakemake_args'],
-            *self.config['targets_by_analysis_level'][analysis_level]
+            f"--configfile {self.updated_config} ",
+            *self.config["snakemake_args"],
+            *self.config["targets_by_analysis_level"][analysis_level],
         ]
 
-        snakemake_cmd = ' '.join(snakemake_cmd_list)
+        snakemake_cmd = " ".join(snakemake_cmd_list)
         run(snakemake_cmd)

--- a/snakebids/snakemake_io.py
+++ b/snakebids/snakemake_io.py
@@ -13,7 +13,7 @@ def regex(filepattern):
     last = 0
     wildcards = set()
     for match in _wildcard_regex.finditer(filepattern):
-        regex_list.append(re.escape(filepattern[last:match.start()]))
+        regex_list.append(re.escape(filepattern[last : match.start()]))
         wildcard = match.group("name")
         if wildcard in wildcards:
             if match.group("constraint"):

--- a/snakebids/tests/test_bids.py
+++ b/snakebids/tests/test_bids.py
@@ -1,6 +1,8 @@
-from ..  import bids
+from .. import bids
+
 
 def test_bids_subj():
-    assert bids(root='bids',subject='001',suffix='T1w.nii.gz') == 'bids/sub-001/sub-001_T1w.nii.gz'
-
-
+    assert (
+        bids(root="bids", subject="001", suffix="T1w.nii.gz")
+        == "bids/sub-001/sub-001_T1w.nii.gz"
+    )

--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -4,14 +4,15 @@ from bids import BIDSLayout
 
 from .. import generate_inputs, __get_lists_from_bids
 
+
 def test_t1w():
-    #create config
-    real_bids_dir = 'snakebids/tests/data/bids_t1w'
+    # create config
+    real_bids_dir = "snakebids/tests/data/bids_t1w"
     derivatives = False
     pybids_inputs = {
-        't1': {
-            'filters': {'suffix': 'T1w'},
-            'wildcards': ['acquisition','subject','session','run']
+        "t1": {
+            "filters": {"suffix": "T1w"},
+            "wildcards": ["acquisition", "subject", "session", "run"],
         }
     }
 
@@ -21,7 +22,7 @@ def test_t1w():
         bids_dir=real_bids_dir,
         derivatives=derivatives,
         participant_label="001",
-        exclude_participant_label="002"
+        exclude_participant_label="002",
     )
     assert config is None
 
@@ -29,43 +30,43 @@ def test_t1w():
     config = generate_inputs(
         pybids_inputs=pybids_inputs,
         bids_dir=real_bids_dir,
-        derivatives=derivatives
+        derivatives=derivatives,
     )
     # Order of the subjects is not deterministic
-    assert config['input_lists'] in  [
-        {'t1': {'acq': ['mprage'], 'subject': ['001', '002']}},
-        {'t1': {'acq': ['mprage'], 'subject': ['002', '001']}}
+    assert config["input_lists"] in [
+        {"t1": {"acq": ["mprage"], "subject": ["001", "002"]}},
+        {"t1": {"acq": ["mprage"], "subject": ["002", "001"]}},
     ]
-    assert config['input_zip_lists'] == {
-        't1': {'acq': ['mprage', 'mprage'], 'subject': ['001', '002']}
+    assert config["input_zip_lists"] == {
+        "t1": {"acq": ["mprage", "mprage"], "subject": ["001", "002"]}
     }
-    assert config['input_wildcards'] == {
-        't1': {'acq': '{acq}', 'subject': '{subject}'}
+    assert config["input_wildcards"] == {
+        "t1": {"acq": "{acq}", "subject": "{subject}"}
     }
-    assert config['subjects'] == ['001', '002']
-    assert config['sessions'] == []
-    assert config['subj_wildcards'] == {'subject': '{subject}'}
+    assert config["subjects"] == ["001", "002"]
+    assert config["sessions"] == []
+    assert config["subj_wildcards"] == {"subject": "{subject}"}
 
     # Two input types, specified by pybids or path override
     wildcard_path_t1 = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
         "data/bids_t1w",
-        "sub-{subject}/anat/sub-{subject}_acq-{acq}_T1w.nii.gz"
+        "sub-{subject}/anat/sub-{subject}_acq-{acq}_T1w.nii.gz",
     )
     wildcard_path_t2 = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
         "data/bids_t1w",
-        "sub-{subject}/anat/sub-{subject}_T2w.nii.gz"
+        "sub-{subject}/anat/sub-{subject}_T2w.nii.gz",
     )
     pybids_inputs = {
-        't1': {
-            'filters': {'suffix': 'T1w'},
-            'wildcards': ['acquisition','subject','session','run']
+        "t1": {
+            "filters": {"suffix": "T1w"},
+            "wildcards": ["acquisition", "subject", "session", "run"],
         },
         "t2": {
             "filters": {"suffix": "T2w"},
-            "wildcards": ["acquisition", "subject", "session", "run"]
-        }
+            "wildcards": ["acquisition", "subject", "session", "run"],
+        },
     }
     bids_dir = real_bids_dir
     for idx in range(2):
@@ -77,50 +78,51 @@ def test_t1w():
         config = generate_inputs(
             pybids_inputs=pybids_inputs,
             bids_dir=bids_dir,
-            derivatives=derivatives
+            derivatives=derivatives,
         )
         # Order of the subjects is not deterministic
-        assert config['input_lists']["t1"] in  [
-            {'acq': ['mprage'], 'subject': ['001', '002']},
-            {'acq': ['mprage'], 'subject': ['002', '001']}
+        assert config["input_lists"]["t1"] in [
+            {"acq": ["mprage"], "subject": ["001", "002"]},
+            {"acq": ["mprage"], "subject": ["002", "001"]},
         ]
         assert config["input_lists"]["t2"] == {"subject": ["002"]}
-        assert config['input_zip_lists']["t1"] in [
-            {'acq': ['mprage', 'mprage'], 'subject': ['001', '002']},
-            {'acq': ['mprage', 'mprage'], 'subject': ['002', '001']}
+        assert config["input_zip_lists"]["t1"] in [
+            {"acq": ["mprage", "mprage"], "subject": ["001", "002"]},
+            {"acq": ["mprage", "mprage"], "subject": ["002", "001"]},
         ]
         assert config["input_zip_lists"]["t2"] == {"subject": ["002"]}
-        assert config['input_wildcards'] == {
-            't1': {'acq': '{acq}', 'subject': '{subject}'},
-            "t2": {"subject": "{subject}"}
+        assert config["input_wildcards"] == {
+            "t1": {"acq": "{acq}", "subject": "{subject}"},
+            "t2": {"subject": "{subject}"},
         }
-        assert config['subjects'] == ['001', '002']
-        assert config['sessions'] == []
-        assert config['subj_wildcards'] == {'subject': '{subject}'}
+        assert config["subjects"] == ["001", "002"]
+        assert config["sessions"] == []
+        assert config["subj_wildcards"] == {"subject": "{subject}"}
+
 
 def test_get_lists_from_bids():
     bids_dir = "snakebids/tests/data/bids_t1w"
     wildcard_path_t1 = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
         "data/bids_t1w",
-        "sub-{subject}/anat/sub-{subject}_acq-{acq}_T1w.nii.gz"
+        "sub-{subject}/anat/sub-{subject}_acq-{acq}_T1w.nii.gz",
     )
     wildcard_path_t2 = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
         "data/bids_t1w",
-        "sub-{subject}/anat/sub-{subject}_T2w.nii.gz"
+        "sub-{subject}/anat/sub-{subject}_T2w.nii.gz",
     )
     print(wildcard_path_t1)
     layout = BIDSLayout(bids_dir, validate=False)
     pybids_inputs = {
-        't1': {
-            'filters': {'suffix': 'T1w'},
-            'wildcards': ['acquisition','subject','session','run']
+        "t1": {
+            "filters": {"suffix": "T1w"},
+            "wildcards": ["acquisition", "subject", "session", "run"],
         },
         "t2": {
             "filters": {"suffix": "T2w"},
-            "wildcards": ["acquisition", "subject", "session", "run"]
-        }
+            "wildcards": ["acquisition", "subject", "session", "run"],
+        },
     }
 
     # Want to test both inputs from layout, both inputs from custom path, and
@@ -134,31 +136,25 @@ def test_get_lists_from_bids():
         config = __get_lists_from_bids(layout, pybids_inputs)
         assert config["input_path"] == {
             "t1": wildcard_path_t1,
-            "t2": wildcard_path_t2
+            "t2": wildcard_path_t2,
         }
         assert config["input_zip_lists"]["t1"] in [
-            {
-                'acq': ['mprage', 'mprage'],
-                'subject': ['001', '002']
-            },
-            {
-                'acq': ['mprage', 'mprage'],
-                'subject': ['002', '001']
-            }
+            {"acq": ["mprage", "mprage"], "subject": ["001", "002"]},
+            {"acq": ["mprage", "mprage"], "subject": ["002", "001"]},
         ]
         assert config["input_zip_lists"]["t2"] == {"subject": ["002"]}
         # The order of multiple wildcard values is not deterministic
-        assert config['input_lists'] in [
+        assert config["input_lists"] in [
             {
-                't1': {'acq': ['mprage'], 'subject': ['001', '002']},
-                "t2": {"subject": ["002"]}
+                "t1": {"acq": ["mprage"], "subject": ["001", "002"]},
+                "t2": {"subject": ["002"]},
             },
             {
-                't1': {'acq': ['mprage'], 'subject': ['002', '001']},
-                "t2": {"subject": ["002"]}
-            }
+                "t1": {"acq": ["mprage"], "subject": ["002", "001"]},
+                "t2": {"subject": ["002"]},
+            },
         ]
-        assert config['input_wildcards'] == {
-            't1': {'acq': '{acq}', 'subject': '{subject}'},
-            "t2": {"subject": "{subject}"}
+        assert config["input_wildcards"] == {
+            "t1": {"acq": "{acq}", "subject": "{subject}"},
+            "t2": {"subject": "{subject}"},
         }

--- a/snakebids/tests/test_snakemake_io.py
+++ b/snakebids/tests/test_snakemake_io.py
@@ -2,57 +2,51 @@
 
 import collections
 
-from ..  import snakemake_io
+from .. import snakemake_io
+
 
 def test_glob_wildcards():
     """Test glob_wildcards() with various patterns"""
     file_path = (
-            "snakebids/tests/data/bids_t1w/sub-001/anat/"
-            "sub-001_acq-mprage_T1w.nii.gz"
+        "snakebids/tests/data/bids_t1w/sub-001/anat/"
+        "sub-001_acq-mprage_T1w.nii.gz"
     )
     empty_wildcards = collections.namedtuple("Wildcards", [])()
     assert snakemake_io.glob_wildcards(file_path) == empty_wildcards
 
     acq_wildcard_path = (
-            "snakebids/tests/data/bids_t1w/sub-001/anat/"
-            "sub-001_acq-{acq}_T1w.nii.gz"
+        "snakebids/tests/data/bids_t1w/sub-001/anat/"
+        "sub-001_acq-{acq}_T1w.nii.gz"
     )
     acq_wildcards = collections.namedtuple("Wildcards", ["acq"])(["mprage"])
     assert snakemake_io.glob_wildcards(acq_wildcard_path) == acq_wildcards
 
-
     # Order of wildcards in the namedtuple is not deterministic
     both_wildcard_path = (
-            "snakebids/tests/data/bids_t1w/sub-{subject}/anat/"
-            "sub-{subject}_acq-{acq}_T1w.nii.gz"
+        "snakebids/tests/data/bids_t1w/sub-{subject}/anat/"
+        "sub-{subject}_acq-{acq}_T1w.nii.gz"
     )
     both_wildcards = [
         collections.namedtuple("Wildcards", ["subject", "acq"])(
-            ["001", "002"],
-            ["mprage", "mprage"]
+            ["001", "002"], ["mprage", "mprage"]
         ),
         collections.namedtuple("Wildcards", ["subject", "acq"])(
-            ["002", "001"],
-            ["mprage", "mprage"]
+            ["002", "001"], ["mprage", "mprage"]
         ),
         collections.namedtuple("Wildcards", ["acq", "subject"])(
-            ["mprage", "mprage"],
-            ["001", "002"]
+            ["mprage", "mprage"], ["001", "002"]
         ),
         collections.namedtuple("Wildcards", ["acq", "subject"])(
-            ["mprage", "mprage"],
-            ["002", "001"]
-        )
+            ["mprage", "mprage"], ["002", "001"]
+        ),
     ]
     both_wildcards_one_file = [
         collections.namedtuple("Wildcards", ["subject", "acq"])(
-            ["001"],
-            ["mprage"]
+            ["001"], ["mprage"]
         ),
         collections.namedtuple("Wildcards", ["acq", "subject"])(
-            ["mprage"],
-            ["001"]
-        )
+            ["mprage"], ["001"]
+        ),
     ]
 
     assert snakemake_io.glob_wildcards(both_wildcard_path) in both_wildcards


### PR DESCRIPTION
Adopting a code formatter ensures that code style is consistent across a project. Here, I've used [Black](https://github.com/psf/black) with the argument `-l 79` to bring all the Snakebids code to a style consistent with PEP 8.

This PR also adds a GitHub action that lints incoming PRs with black, to ensure that the incoming code is also formatted according to that style.