### PR TITLE
bugfix: preserve ordering when removing dupes

### DIFF
--- a/snakebids/snakemake_io.py
+++ b/snakebids/snakemake_io.py
@@ -93,8 +93,8 @@ def glob_wildcards(pattern, files=None, followlinks=False):
         match.group("name") for match in _wildcard_regex.finditer(pattern)
     ]
 
-    # remove duplicates:
-    names = list(set(names))
+    # remove duplicates while preserving ordering
+    names = list(collections.OrderedDict.fromkeys(names))
 
     # pylint: disable-msg=invalid-name
     Wildcards = collections.namedtuple("Wildcards", names)


### PR DESCRIPTION
Fixes the issue where ordering is lost when removing duplicate wildcards (#31)