### PR TITLE
Resolve arguments annotated with type: Path 

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -23,6 +23,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install pytest
+        python -m pip install pytest-mock
         python -m pip install -e .
     - name: Test with pytest
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VS Code
+.vscode

--- a/docs/tutorial/tutorial.rst
+++ b/docs/tutorial/tutorial.rst
@@ -372,10 +372,13 @@ However, we will first need to add some additional information to our config fil
       --derivatives:
         help: 'Path(s) to a derivatives dataset, for folder(s) that contains multiple derivatives datasets (default: %(default)s) '
         default: False
+        type: Path
         nargs: '+'
 
 
 The above is standard boilerplate for any BIDS app.  You can also define any new command-line arguments you wish. Snakebids uses the ``argparse`` module, and each entry in this ``parse_args`` dict thus becomes a call to ``add_argument()`` from ``argparse``. When you run the workflow, snakebids adds the named argument values to the config dict, so your workflow can make use of it as if you had manually added the variable to your configfile. 
+
+Arguments that will receive paths should be given the item ``type: Path``, as is done for ``--derivatives`` in the example above. Without this annotation, paths given to keyword arguments will be interpreted relative to the output directory. Indicating ``type: Path`` will tell Snakebids to first resolve the path according to your current working directory 
 
 BIDS apps also have a requried ``analysis_level`` positional argument, so there are some config variables to set this as well. The analysis levels are in an ``analysis_levels`` list in the config, and also as keys in a ``targets_by_analysis_level`` dict, which can be used to map each analysis level to the name of a target rule::
 

--- a/docs/tutorial/tutorial.rst
+++ b/docs/tutorial/tutorial.rst
@@ -378,7 +378,7 @@ However, we will first need to add some additional information to our config fil
 
 The above is standard boilerplate for any BIDS app.  You can also define any new command-line arguments you wish. Snakebids uses the ``argparse`` module, and each entry in this ``parse_args`` dict thus becomes a call to ``add_argument()`` from ``argparse``. When you run the workflow, snakebids adds the named argument values to the config dict, so your workflow can make use of it as if you had manually added the variable to your configfile. 
 
-Arguments that will receive paths should be given the item ``type: Path``, as is done for ``--derivatives`` in the example above. Without this annotation, paths given to keyword arguments will be interpreted relative to the output directory. Indicating ``type: Path`` will tell Snakebids to first resolve the path according to your current working directory 
+Arguments that will receive paths should be given the item ``type: Path``, as is done for ``--derivatives`` in the example above. Without this annotation, paths given to keyword arguments will be interpreted relative to the output directory. Indicating ``type: Path`` will tell Snakebids to first resolve the path according to your current working directory.
 
 BIDS apps also have a requried ``analysis_level`` positional argument, so there are some config variables to set this as well. The analysis levels are in an ``analysis_levels`` list in the config, and also as keys in a ``targets_by_analysis_level`` dict, which can be used to map each analysis level to the name of a target rule::
 

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,7 @@ setuptools.setup(
         "pybids==0.12.3",
         "snakemake>=5.28.0",
         "PyYAML>=5.3.1",
-        "cookiecutter>=1.7.2",
-        "pytest-mock==3.6.1"
+        "cookiecutter>=1.7.2"
     ],
     python_requires=">=3.7",
 )

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setuptools.setup(
         "snakemake>=5.28.0",
         "PyYAML>=5.3.1",
         "cookiecutter>=1.7.2",
+        "pytest-mock==3.6.1"
     ],
     python_requires=">=3.7",
 )

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -236,6 +236,14 @@ class SnakeBidsApp:
 
         # update the parser with config options
         for name, parse_args in self.config["parse_args"].items():
+            if "type" in parse_args:
+                type_ = parse_args["type"]
+                if not type_ in globals():
+                    raise TypeError(
+                        f"{type_} is not available "
+                        f"as a type for {name}"
+                    )
+                parse_args["type"] = globals()[parse_args["type"]]
             app_group.add_argument(name, **parse_args)
 
         # general parser for

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -3,7 +3,6 @@
 """Tools to generate a Snakemake-based BIDS app."""
 
 import os
-from pathlib import Path
 import pathlib
 import subprocess
 import argparse
@@ -13,6 +12,8 @@ import yaml
 import bids
 import snakemake
 from snakemake.io import load_configfile
+
+Path = pathlib.Path
 
 bids.config.set_option("extension_initial_dot", True)
 logger = logging.Logger(__name__)

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -4,6 +4,7 @@
 
 import os
 from pathlib import Path
+import pathlib
 import subprocess
 import argparse
 import logging
@@ -401,6 +402,12 @@ class SnakeBidsApp:
                                             dumper.represent_mapping(
                                                 'tag:yaml.org,2002:map',
                                                 data.items()))
+
+                # Represent any PathLikes as str.
+                path2str = lambda dumper, data: dumper.represent_scalar('tag:yaml.org,2002:str',str(data))
+                yaml.add_representer(pathlib.PosixPath, path2str)
+                yaml.add_representer(pathlib.WindowsPath, path2str)
+
                 yaml.dump(dict(self.config),
                             f, 
                             default_flow_style=False,

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -89,7 +89,14 @@ def get_time_hash():
     hash.update(str(time.time()).encode('utf-8'))
     return hash.hexdigest()[:8]
 
-
+def resolve_path(path_candidate):
+    if isinstance(path_candidate, list):
+        return [resolve_path(p) for p in path_candidate]
+    elif isinstance(path_candidate, os.PathLike):
+        
+        return path_candidate.resolve()
+    else:
+        return path_candidate
 
 SNAKEFILE_CHOICES = [
     "Snakefile",
@@ -318,6 +325,11 @@ class SnakeBidsApp:
         args = all_args[0]
         snakemake_args = all_args[1]
 
+        # resolve all path items to get absolute paths
+        args.__dict__ = {
+            k: resolve_path(v) for k, v in args.__dict__.items()
+        }
+
         # add snakebids arguments to config
         self.config.update(args.__dict__)
 
@@ -359,7 +371,7 @@ class SnakeBidsApp:
         self.config["bids_dir"] = Path(self.config["bids_dir"]).resolve()
         self.config["output_dir"] = Path(self.config["output_dir"]).resolve()
 
-
+    
     def write_updated_config(self):
         """Create an updated snakebids config file in the output dir."""
         self.updated_config = Path(self.config["output_dir"],

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -379,7 +379,7 @@ class SnakeBidsApp:
 
 
         # create the output folder if needed
-        self.updated_config.parent.mkdir(exist_ok=True)
+        self.updated_config.parent.mkdir(parents = True, exist_ok=True)
 
 
         time_hash = get_time_hash() # TODO: copy to a time-hashed file too

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -13,6 +13,9 @@ import bids
 import snakemake
 from snakemake.io import load_configfile
 
+# We define Path here in addition to pathlib to put both variables in globals()
+# This way, users specifying a path type in their config.yaml can indicate
+# either Path or pathlib.Path
 Path = pathlib.Path
 
 bids.config.set_option("extension_initial_dot", True)

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -243,7 +243,8 @@ class SnakeBidsApp:
 
         # update the parser with config options
         for name, parse_args in self.config["parse_args"].items():
-            if "type" in parse_args:
+            # Convert type annotations froms strings to class types
+            if "type" in parse_args and isinstance(parse_args["type"], str):
                 type_ = parse_args["type"]
                 if not type_ in globals():
                     raise TypeError(
@@ -324,7 +325,6 @@ class SnakeBidsApp:
 
         args = all_args[0]
         snakemake_args = all_args[1]
-
         # resolve all path items to get absolute paths
         args.__dict__ = {
             k: resolve_path(v) for k, v in args.__dict__.items()

--- a/snakebids/tests/mock/config.py
+++ b/snakebids/tests/mock/config.py
@@ -1,0 +1,54 @@
+config = {
+   "pybids_inputs": {
+      "bold": {
+         "filters": {
+            "suffix": "bold",
+            "extension": ".nii.gz",
+            "datatype": "func"
+         },
+         "wildcards": [
+            "subject",
+            "session",
+            "acquisition",
+            "task",
+            "run"
+         ]
+      }
+   },
+   "targets_by_analysis_level": {
+      "participant": [
+         ""
+      ]
+   },
+   "analysis_levels": [
+      "participant"
+   ],
+   "parse_args": {
+      "bids_dir": {
+         "help": "The directory with the input dataset formatted according\nto the BIDS standard."
+      },
+      "output_dir": {
+         "help": "The directory where the output files\nshould be stored. If you are running group level analysis\nthis folder should be prepopulated with the results of the\nparticipant level analysis."
+      },
+      "analysis_level": {
+         "help": "Level of the analysis that will be performed.",
+         "choices": [
+            "participant"
+         ]
+      },
+      "--participant_label": {
+         "help": "The label(s) of the participant(s) that should be analyzed. The label\ncorresponds to sub-<participant_label> from the BIDS spec \n(so it does not include \"sub-\"). If this parameter is not \nprovided all subjects should be analyzed. Multiple \nparticipants can be specified with a space separated list.",
+         "nargs": "+"
+      },
+      "--exclude_participant_label": {
+         "help": "The label(s) of the participant(s) that should be excluded. The label\ncorresponds to sub-<participant_label> from the BIDS spec \n(so it does not include \"sub-\"). If this parameter is not \nprovided all subjects should be analyzed. Multiple \nparticipants can be specified with a space separated list.",
+         "nargs": "+"
+      },
+      "--derivatives": {
+         "help": "Path(s) to a derivatives dataset, for folder(s) that contains multiple derivatives datasets (default: %(default)s) ",
+         "default": False,
+         "type": "Path",
+         "nargs": "+"
+      }
+   }
+}

--- a/snakebids/tests/mock/config.yaml
+++ b/snakebids/tests/mock/config.yaml
@@ -1,0 +1,67 @@
+bids_dir: '../bids'
+
+fwhm:
+  - 5
+  - 10
+  - 15
+  - 20
+
+pybids_inputs:
+  bold:
+    filters:
+      suffix: 'bold'
+      extension: '.nii.gz'
+      datatype: 'func'
+    wildcards:
+      - subject
+      - session
+      - acquisition
+      - task
+      - run
+      
+    
+targets_by_analysis_level:
+  participant:
+    - ''  # if '', then the first rule is run
+
+analysis_levels: &analysis_levels
+ - participant
+ 
+
+parse_args:
+
+  bids_dir:
+    help: The directory with the input dataset formatted according 
+          to the BIDS standard.
+
+  output_dir:
+    help: The directory where the output files 
+          should be stored. If you are running group level analysis
+          this folder should be prepopulated with the results of the
+          participant level analysis.
+
+  analysis_level: 
+    help: Level of the analysis that will be performed. 
+    choices: *analysis_levels
+
+  --participant_label:
+    help: The label(s) of the participant(s) that should be analyzed. The label 
+          corresponds to sub-<participant_label> from the BIDS spec 
+          (so it does not include "sub-"). If this parameter is not 
+          provided all subjects should be analyzed. Multiple 
+          participants can be specified with a space separated list.
+    nargs: '+'
+
+  --exclude_participant_label:
+    help: The label(s) of the participant(s) that should be excluded. The label 
+          corresponds to sub-<participant_label> from the BIDS spec 
+          (so it does not include "sub-"). If this parameter is not 
+          provided all subjects should be analyzed. Multiple 
+          participants can be specified with a space separated list.
+    nargs: '+'
+
+  --derivatives:
+    help: 'Path(s) to a derivatives dataset, for folder(s) that contains multiple derivatives datasets (default: %(default)s) '
+    default: False
+    type: Path
+    nargs: '+'

--- a/snakebids/tests/test_app.py
+++ b/snakebids/tests/test_app.py
@@ -1,0 +1,41 @@
+from pytest_mock.plugin import MockerFixture
+from ..app import SnakeBidsApp
+from .mock.config import config
+from unittest.mock import patch
+import pytest
+import sys, copy
+
+def init_snakebids_app(self):
+    self.configfile_path="mock/config.yaml"
+    self.snakefile = "mock/Snakefile"
+    self.config = copy.deepcopy(config)
+
+
+
+@pytest.fixture
+def app(mocker: MockerFixture):
+    mocker.patch.object(SnakeBidsApp, '__init__', init_snakebids_app)
+    return SnakeBidsApp()
+
+
+class TestCreateParser:
+    mock_args_special= ["--derivatives", "path/to/nowhere"]
+    mock_basic_args = ["script_name", "path/to/input", "path/to/output", "participant"]
+    mock_all_args = mock_basic_args + mock_args_special 
+    def test_snakebids_app_is_properly_mocked(self, app):
+        assert isinstance(app, SnakeBidsApp)
+        assert not hasattr(app, "parser")
+
+    def test_fails_if_missing_arguments(self, app, mocker: MockerFixture):
+        mocker.patch.object(sys, 'argv', self.mock_args_special)
+        parser = app._SnakeBidsApp__create_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args()
+
+    def test_succeeds_if_given_positional_args(self, app, mocker: MockerFixture):
+        mocker.patch.object(sys, 'argv', self.mock_basic_args)
+        parser = app._SnakeBidsApp__create_parser()
+        print(sys.argv)
+        print(parser.parse_args())
+        assert False
+    

--- a/snakebids/tests/test_app.py
+++ b/snakebids/tests/test_app.py
@@ -1,13 +1,21 @@
+# Core
+import sys, copy
+from pathlib import Path
+
+# Testing 
+import pytest
+
+# Typings
 from argparse import ArgumentParser
 from os import PathLike
-from pathlib import Path
 from configargparse import Namespace
+
+# Fixtures
 from pytest_mock.plugin import MockerFixture
+
+# Local
 from ..app import SnakeBidsApp, resolve_path
 from .mock.config import config
-from unittest.mock import patch
-import pytest
-import sys, copy
 
 def init_snakebids_app(self):
     self.configfile_path="mock/config.yaml"

--- a/snakebids/tests/test_app.py
+++ b/snakebids/tests/test_app.py
@@ -1,3 +1,6 @@
+from argparse import ArgumentParser
+from os import PathLike
+from configargparse import Namespace
 from pytest_mock.plugin import MockerFixture
 from ..app import SnakeBidsApp
 from .mock.config import config
@@ -11,31 +14,42 @@ def init_snakebids_app(self):
     self.config = copy.deepcopy(config)
 
 
-
-@pytest.fixture
-def app(mocker: MockerFixture):
-    mocker.patch.object(SnakeBidsApp, '__init__', init_snakebids_app)
-    return SnakeBidsApp()
-
-
 class TestCreateParser:
     mock_args_special= ["--derivatives", "path/to/nowhere"]
     mock_basic_args = ["script_name", "path/to/input", "path/to/output", "participant"]
     mock_all_args = mock_basic_args + mock_args_special 
+
+    @pytest.fixture
+    def app(self, mocker: MockerFixture):
+        mocker.patch.object(SnakeBidsApp, '__init__', init_snakebids_app)
+        return SnakeBidsApp()
+
+    @pytest.fixture
+    def parser(self, app):
+        return app._SnakeBidsApp__create_parser()
+
     def test_snakebids_app_is_properly_mocked(self, app):
         assert isinstance(app, SnakeBidsApp)
         assert not hasattr(app, "parser")
 
-    def test_fails_if_missing_arguments(self, app, mocker: MockerFixture):
-        mocker.patch.object(sys, 'argv', self.mock_args_special)
-        parser = app._SnakeBidsApp__create_parser()
+    def test_fails_if_missing_arguments(self, parser: ArgumentParser, mocker: MockerFixture):
+        mocker.patch.object(sys, 'argv', ["script_name"])
         with pytest.raises(SystemExit):
             parser.parse_args()
 
-    def test_succeeds_if_given_positional_args(self, app, mocker: MockerFixture):
+    def test_succeeds_if_given_positional_args(self, parser: ArgumentParser, mocker: MockerFixture):
         mocker.patch.object(sys, 'argv', self.mock_basic_args)
-        parser = app._SnakeBidsApp__create_parser()
-        print(sys.argv)
-        print(parser.parse_args())
-        assert False
+        assert isinstance(parser.parse_args(), Namespace)
+
+    def test_converts_type_path_into_pathlike(self, parser: ArgumentParser, mocker: MockerFixture):
+        mocker.patch.object(sys, 'argv', self.mock_all_args)
+        args = parser.parse_args()
+        assert isinstance(getattr(args, "derivatives")[0], PathLike)
     
+    def test_fails_if_undefined_type_given(self, app: SnakeBidsApp, mocker: MockerFixture):
+        app.config["parse_args"]["--new-param"] = {
+            "help": "Generic Help Message",
+            "type": "UnheardClass"
+        }
+        with pytest.raises(TypeError):
+            app._SnakeBidsApp__create_parser()


### PR DESCRIPTION
# Problem
Currently, when supplying arguments to the command line executable (e.g. `run.py`), the `input` and `output` positional arguments are resolved (e.g. `./data` becomes `/home/user/folder/data`) and a new `config.yaml` is generated in the output folder. All keyword arguments (e.g. `--keyword argument`) are printed into the new `config.yaml` as `keyword: argument`. Snakemake is then run using the new config file as config and using the output dir as the working directory. The equivalent snakemake call would be 
```
snakemake --configfile /path/to/output/dir/config/config.yaml --directory /path/to/output/dir
```

Because the working directory is switched, any additional relative paths supplied to the original `run.py` call will now be interpreted relative to the output directory. For instance, if the user had an argument `--supporting-data ./path/to/data`, this path would be evaluated relative to the output folder. Snakemake would search for the data at `/path/to/output/dir/path/to/data`. The user, however, would expect snakemake to look for the folder at a location relative to where `run.py` was called.

# Solution
Argparse allows arguments to be annotated as a specific type such as `str`, `int`, etc. The solution here was to allow users to annotate arguments with either `Path` or `pathlib.Path`. `app.py` will convert these files to `Path`s and resolve them before printing them into the new `config.yaml`. Note that any arguments not annotated with Path will not be affected, even if they look like paths. 

If the solution is green-lit, I can update the documentation to reflect this new behaviour. EDIT: I added some documentation

A final side-note, I refactored `app.py` to use the more modern `pathlib` module rather than `os.path`. Should have been its own issue, but it's baked into the code now. Everything's been tested and checks out.