### PR TITLE
Accepts pathlib.Path as root in bids function

### DIFF
--- a/snakebids/__init__.py
+++ b/snakebids/__init__.py
@@ -38,7 +38,7 @@ def bids(
 
     Parameters
     ----------
-    root : str, default=None
+    root : str or Path, default=None
         root folder to include in the path (e.g. 'results')
     datatype : str, default=None
         folder to include after sub-/ses- (e.g. anat, dwi )

--- a/snakebids/__init__.py
+++ b/snakebids/__init__.py
@@ -4,6 +4,7 @@ import os
 from os.path import join
 from collections import OrderedDict
 import json
+from pathlib import Path
 import re
 import logging
 
@@ -175,6 +176,8 @@ def bids(
     # root directory
     if isinstance(root, str):
         folder.append(root)
+    elif isinstance(root, Path):
+        folder.append(str(root.resolve()))
 
     # if prefix is defined, put it before other anything else
     if isinstance(prefix, str):
@@ -473,10 +476,8 @@ def __read_bids_tags(bids_json=None):
     dict:
         Dictionary of bids tags"""
     if bids_json is None:
-        bids_json = os.path.join(
-            os.path.dirname(os.path.realpath(__file__)), "bids_tags.json"
-        )
-    with open(bids_json, "r") as infile:
+        bids_json = Path(__file__).parent.resolve() / "bids_tags.json"
+    with bids_json.open("r") as infile:
         bids_tags = json.load(infile)
     return bids_tags
 

--- a/snakebids/tests/test_bids.py
+++ b/snakebids/tests/test_bids.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from .. import bids
 
 
@@ -5,4 +6,8 @@ def test_bids_subj():
     assert (
         bids(root="bids", subject="001", suffix="T1w.nii.gz")
         == "bids/sub-001/sub-001_T1w.nii.gz"
+    )
+    assert (
+        bids(root=Path("bids"), subject="001", suffix="T1w.nii.gz")
+        == str(Path.cwd() / "bids/sub-001/sub-001_T1w.nii.gz")
     )


### PR DESCRIPTION
Previously, `bids()` only accepted `str`. This extends it to allow `pathlib.Path`s.

I also refactored the `os.path.join()` calls `__init__.py` to use pathlib.