### PR TITLE
upgrade pybids version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
         ],
     },
     install_requires=[
-        "pybids==0.12.3",
+        "pybids>=0.13.2",
         "snakemake>=5.28.0",
         "PyYAML>=5.3.1",
         "cookiecutter>=1.7.2"


### PR DESCRIPTION
upgrades to pybids 0.13.2. Doesn't seem to break anything as far as I can tell, and updates the bids entities etc..