### PR TITLE
Fixes for pybids dataset_description.json compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setuptools.setup(
     entry_points={
         "console_scripts": [
             "snakebids-create=snakebids.template:main",
+            "snakebids-fix-dd=snakebids.fix_dd:main",
         ],
     },
     install_requires=[

--- a/snakebids/fix_dd.py
+++ b/snakebids/fix_dd.py
@@ -9,7 +9,7 @@ def get_parser():
         description="Update BIDS Derivatives Dataset  to be backwards compatible with pybids",
         epilog=("Adds PipelineDescription.Name to the dataset_description.json file, from earlier BIDS spec) that pybids requires, using the first entry of the GeneratedBy list.  This is needed if parsing a modern version of fmriprep derivatives with snakebids/pybids."),
     )
-    parser.add_argument("dataset_root", help="BIDS derivative dataset to fix")
+    parser.add_argument("dataset_root","dataset-root", help="BIDS derivative dataset to fix")
     return parser
 
 

--- a/snakebids/fix_dd.py
+++ b/snakebids/fix_dd.py
@@ -3,10 +3,12 @@ from pathlib import Path
 import json
 import argparse
 
+
 def get_parser():
     parser = argparse.ArgumentParser(
-                    description='Update dataset_description.json file to be backwards compatible with pybids',
-                    epilog='Adds PipelineDescription.Name (from earlier BIDS spec) that pybids requires. This is needed if parsing a modern version of fmriprep derivatives with snakebids/pybids.')
+        description="Update BIDS Derivatives Dataset  to be backwards compatible with pybids",
+        epilog=("Adds PipelineDescription.Name to the dataset_description.json file, from earlier BIDS spec) that pybids requires, using the first entry of the GeneratedBy list.  This is needed if parsing a modern version of fmriprep derivatives with snakebids/pybids."),
+    )
     parser.add_argument("dataset_root", help="BIDS derivative dataset to fix")
     return parser
 
@@ -17,32 +19,34 @@ def main():
 
     root_path = Path(args.dataset_root)
 
-    #check if a dataset_description.json file exists
-    json_path = root_path.joinpath('dataset_description.json')
-       
-    #read the dataset_description json file
+    # check if a dataset_description.json file exists
+    json_path = root_path.joinpath("dataset_description.json")
+
+    # read the dataset_description json file
     with open(json_path) as f:
         dataset_dict = json.load(f)
 
-    if 'PipelineDescription' in dataset_dict.keys():
-        if 'Name' in dataset_dict['PipelineDescription'].keys():
-            print(f'{json_path} already compatible with pybids')
+    if "PipelineDescription" in dataset_dict.keys():
+        if "Name" in dataset_dict["PipelineDescription"].keys():
+            print(f"{json_path} already compatible with pybids")
             return
 
-    pipeline_name = dataset_dict['GeneratedBy'][0]['Name']
-    pipeline_version = dataset_dict['GeneratedBy'][0]['Version']
+    pipeline_name = dataset_dict["GeneratedBy"][0]["Name"]
+    pipeline_version = dataset_dict["GeneratedBy"][0]["Version"]
 
-    #add to the dict
-    print(f'Adding PipelineDescription: \{ Name: {pipeline_name}, Version: {pipeline_version} \}')
+    # add to the dict
+    print(
+        f"Adding PipelineDescription.Name: {pipeline_name}, PipelineDescription.Version: {pipeline_version}"
+    )
 
-    dataset_dict['PipelineDescription'] = {'Name': pipeline_name,
-                                            'Version': pipeline_version}
+    dataset_dict["PipelineDescription"] = {
+        "Name": pipeline_name,
+        "Version": pipeline_version,
+    }
 
-    print(f'Saving to {json_path}')
-    with open(json_path, 'w') as write_file:
+    print(f"Saving to {json_path}")
+    with open(json_path, "w") as write_file:
         json.dump(dataset_dict, write_file, indent=4, sort_keys=True)
-
-            
 
 
 if __name__ == "__main__":

--- a/snakebids/fix_dd.py
+++ b/snakebids/fix_dd.py
@@ -1,0 +1,49 @@
+""" Script to fix dataset_description.json PyBIDS compatibility """
+from pathlib import Path
+import json
+import argparse
+
+def get_parser():
+    parser = argparse.ArgumentParser(
+                    description='Update dataset_description.json file to be backwards compatible with pybids',
+                    epilog='Adds PipelineDescription.Name (from earlier BIDS spec) that pybids requires. This is needed if parsing a modern version of fmriprep derivatives with snakebids/pybids.')
+    parser.add_argument("dataset_root", help="BIDS derivative dataset to fix")
+    return parser
+
+
+def main():
+    parser = get_parser()
+    args = parser.parse_args()
+
+    root_path = Path(args.dataset_root)
+
+    #check if a dataset_description.json file exists
+    json_path = root_path.joinpath('dataset_description.json')
+       
+    #read the dataset_description json file
+    with open(json_path) as f:
+        dataset_dict = json.load(f)
+
+    if 'PipelineDescription' in dataset_dict.keys():
+        if 'Name' in dataset_dict['PipelineDescription'].keys():
+            print(f'{json_path} already compatible with pybids')
+            return
+
+    pipeline_name = dataset_dict['GeneratedBy'][0]['Name']
+    pipeline_version = dataset_dict['GeneratedBy'][0]['Version']
+
+    #add to the dict
+    print(f'Adding PipelineDescription: \{ Name: {pipeline_name}, Version: {pipeline_version} \}')
+
+    dataset_dict['PipelineDescription'] = {'Name': pipeline_name,
+                                            'Version': pipeline_version}
+
+    print(f'Saving to {json_path}')
+    with open(json_path, 'w') as write_file:
+        json.dump(dataset_dict, write_file, indent=4, sort_keys=True)
+
+            
+
+
+if __name__ == "__main__":
+    main()

--- a/snakebids/project_template/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/pipeline_description.json
+++ b/snakebids/project_template/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/pipeline_description.json
@@ -2,6 +2,14 @@
     "Name": "{{cookiecutter.app_name}} - {{cookiecutter.app_description}}",
     "BIDSVersion": "1.4.0",
     "DatasetType": "derivative",
+    "PipelineDescription":
+        {
+            "Name": "{{cookiecutter.app_name}}",
+            "Version": "0.1.0",
+            "CodeURL": "http://github.com/{{cookiecutter.github_username}}/{{cookiecutter.app_name}}",
+            "Author": "{{cookiecutter.full_name}}",
+            "AuthorEmail": "{{cookiecutter.email}}"
+        },
     "GeneratedBy": [
         {
             "Name": "{{cookiecutter.app_name}}",

--- a/snakebids/tests/data/fmriprep_deriv/dataset_description.json
+++ b/snakebids/tests/data/fmriprep_deriv/dataset_description.json
@@ -1,0 +1,20 @@
+{
+    "Name": "fMRIPrep - fMRI PREProcessing workflow",
+    "BIDSVersion": "1.4.0",
+    "DatasetType": "derivative",
+    "GeneratedBy": [
+        {
+            "Name": "fMRIPrep",
+            "Version": "21.0.0rc1",
+            "CodeURL": "https://github.com/nipreps/fmriprep/archive/21.0.0rc1.tar.gz"
+        }
+    ],
+    "HowToAcknowledge": "Please cite our paper (https://doi.org/10.1038/s41592-018-0235-4), and include the generated citation boilerplate within the Methods section of the text.",
+    "SourceDatasets": [
+        {
+            "URL": "https://doi.org/TODO: eventually a DOI for the dataset",
+            "DOI": "TODO: eventually a DOI for the dataset"
+        }
+    ],
+    "License": "TODO: choose a license, e.g. PDDL (http://opendatacommons.org/licenses/pddl/)"
+}


### PR DESCRIPTION
Pybids is still a bit behind when it comes to parsing BIDS derivatives datasets, since the new BIDS spec (that e.g. fmriprep uses) uses a `GeneratedBy` list in the dataset_description.json, which supercedes the older `PIpelineDescription.Name` used by Pybids to parse a dataset. 

This PR adds a tool to add in a PipelineDescription to an existing dataset_description file, using the first entry of the GeneratedBy list to get the name and version. This is so we can more easily use BIDS derivatives in snakebids. Once Pybids is fixed to deal with this properly, we can ditch this, but it solves the problem for now. 

I've also added the PIpelineDescription field to our template project files, so that nakebids outputs are also compatible with pybids/snakebids when parsing as a derivative.