### PR TITLE
Implement workflow and bidsapp mode

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -529,6 +529,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "progress"
+version = "1.6"
+description = "Easy to use progress bars"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "psutil"
 version = "5.8.0"
 description = "Cross-platform lib for process and system monitoring in Python."
@@ -935,7 +943,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7"
-content-hash = "ac480602aa91cbc60d368e585b6d9012aa4affcc1d77b837ecc186e8f720563b"
+content-hash = "b28be048cc01445bf8d9a5594c12df2798912bb642b891319214c54b03984532"
 
 [metadata.files]
 appdirs = [
@@ -1253,6 +1261,9 @@ pluggy = [
 poyo = [
     {file = "poyo-0.5.0-py2.py3-none-any.whl", hash = "sha256:3e2ca8e33fdc3c411cd101ca395668395dd5dc7ac775b8e809e3def9f9fe041a"},
     {file = "poyo-0.5.0.tar.gz", hash = "sha256:e26956aa780c45f011ca9886f044590e2d8fd8b61db7b1c1cf4e0869f48ed4dd"},
+]
+progress = [
+    {file = "progress-1.6.tar.gz", hash = "sha256:c9c86e98b5c03fa1fe11e3b67c1feda4788b8d0fe7336c2ff7d5644ccfba34cd"},
 ]
 psutil = [
     {file = "psutil-5.8.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:0066a82f7b1b37d334e68697faba68e5ad5e858279fd6351c8ca6024e8d6ba64"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -657,7 +657,7 @@ test = ["pytest (>=3.0)", "pytest-asyncio"]
 
 [[package]]
 name = "regex"
-version = "2021.10.23"
+version = "2021.11.2"
 description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
@@ -893,7 +893,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7"
-content-hash = "5e7a7074a7b0645cb2ad880010929d8eb519134ac305b81ad06f1a62eb9a51b7"
+content-hash = "d009269f65da660d816193916f720eb295b6422c8cb1450af68309642f63b8a1"
 
 [metadata.files]
 appdirs = [
@@ -1341,42 +1341,55 @@ ratelimiter = [
     {file = "ratelimiter-1.2.0.post0.tar.gz", hash = "sha256:5c395dcabdbbde2e5178ef3f89b568a3066454a6ddc223b76473dac22f89b4f7"},
 ]
 regex = [
-    {file = "regex-2021.10.23-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:45b65d6a275a478ac2cbd7fdbf7cc93c1982d613de4574b56fd6972ceadb8395"},
-    {file = "regex-2021.10.23-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:74d071dbe4b53c602edd87a7476ab23015a991374ddb228d941929ad7c8c922e"},
-    {file = "regex-2021.10.23-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:34d870f9f27f2161709054d73646fc9aca49480617a65533fc2b4611c518e455"},
-    {file = "regex-2021.10.23-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fb698037c35109d3c2e30f2beb499e5ebae6e4bb8ff2e60c50b9a805a716f79"},
-    {file = "regex-2021.10.23-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cb46b542133999580ffb691baf67410306833ee1e4f58ed06b6a7aaf4e046952"},
-    {file = "regex-2021.10.23-cp310-cp310-win32.whl", hash = "sha256:5e9c9e0ce92f27cef79e28e877c6b6988c48b16942258f3bc55d39b5f911df4f"},
-    {file = "regex-2021.10.23-cp310-cp310-win_amd64.whl", hash = "sha256:ab7c5684ff3538b67df3f93d66bd3369b749087871ae3786e70ef39e601345b0"},
-    {file = "regex-2021.10.23-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:de557502c3bec8e634246588a94e82f1ee1b9dfcfdc453267c4fb652ff531570"},
-    {file = "regex-2021.10.23-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ee684f139c91e69fe09b8e83d18b4d63bf87d9440c1eb2eeb52ee851883b1b29"},
-    {file = "regex-2021.10.23-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5095a411c8479e715784a0c9236568ae72509450ee2226b649083730f3fadfc6"},
-    {file = "regex-2021.10.23-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b568809dca44cb75c8ebb260844ea98252c8c88396f9d203f5094e50a70355f"},
-    {file = "regex-2021.10.23-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:eb672217f7bd640411cfc69756ce721d00ae600814708d35c930930f18e8029f"},
-    {file = "regex-2021.10.23-cp36-cp36m-win32.whl", hash = "sha256:a7a986c45d1099a5de766a15de7bee3840b1e0e1a344430926af08e5297cf666"},
-    {file = "regex-2021.10.23-cp36-cp36m-win_amd64.whl", hash = "sha256:6d7722136c6ed75caf84e1788df36397efdc5dbadab95e59c2bba82d4d808a4c"},
-    {file = "regex-2021.10.23-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:9f665677e46c5a4d288ece12fdedf4f4204a422bb28ff05f0e6b08b7447796d1"},
-    {file = "regex-2021.10.23-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:450dc27483548214314640c89a0f275dbc557968ed088da40bde7ef8fb52829e"},
-    {file = "regex-2021.10.23-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:129472cd06062fb13e7b4670a102951a3e655e9b91634432cfbdb7810af9d710"},
-    {file = "regex-2021.10.23-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a940ca7e7189d23da2bfbb38973832813eab6bd83f3bf89a977668c2f813deae"},
-    {file = "regex-2021.10.23-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:530fc2bbb3dc1ebb17f70f7b234f90a1dd43b1b489ea38cea7be95fb21cdb5c7"},
-    {file = "regex-2021.10.23-cp37-cp37m-win32.whl", hash = "sha256:ded0c4a3eee56b57fcb2315e40812b173cafe79d2f992d50015f4387445737fa"},
-    {file = "regex-2021.10.23-cp37-cp37m-win_amd64.whl", hash = "sha256:391703a2abf8013d95bae39145d26b4e21531ab82e22f26cd3a181ee2644c234"},
-    {file = "regex-2021.10.23-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be04739a27be55631069b348dda0c81d8ea9822b5da10b8019b789e42d1fe452"},
-    {file = "regex-2021.10.23-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13ec99df95003f56edcd307db44f06fbeb708c4ccdcf940478067dd62353181e"},
-    {file = "regex-2021.10.23-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8d1cdcda6bd16268316d5db1038965acf948f2a6f43acc2e0b1641ceab443623"},
-    {file = "regex-2021.10.23-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0c186691a7995ef1db61205e00545bf161fb7b59cdb8c1201c89b333141c438a"},
-    {file = "regex-2021.10.23-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2b20f544cbbeffe171911f6ce90388ad36fe3fad26b7c7a35d4762817e9ea69c"},
-    {file = "regex-2021.10.23-cp38-cp38-win32.whl", hash = "sha256:c0938ddd60cc04e8f1faf7a14a166ac939aac703745bfcd8e8f20322a7373019"},
-    {file = "regex-2021.10.23-cp38-cp38-win_amd64.whl", hash = "sha256:56f0c81c44638dfd0e2367df1a331b4ddf2e771366c4b9c5d9a473de75e3e1c7"},
-    {file = "regex-2021.10.23-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:80bb5d2e92b2258188e7dcae5b188c7bf868eafdf800ea6edd0fbfc029984a88"},
-    {file = "regex-2021.10.23-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1dae12321b31059a1a72aaa0e6ba30156fe7e633355e445451e4021b8e122b6"},
-    {file = "regex-2021.10.23-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1f2b59c28afc53973d22e7bc18428721ee8ca6079becf1b36571c42627321c65"},
-    {file = "regex-2021.10.23-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d134757a37d8640f3c0abb41f5e68b7cf66c644f54ef1cb0573b7ea1c63e1509"},
-    {file = "regex-2021.10.23-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0dcc0e71118be8c69252c207630faf13ca5e1b8583d57012aae191e7d6d28b84"},
-    {file = "regex-2021.10.23-cp39-cp39-win32.whl", hash = "sha256:a30513828180264294953cecd942202dfda64e85195ae36c265daf4052af0464"},
-    {file = "regex-2021.10.23-cp39-cp39-win_amd64.whl", hash = "sha256:0f7552429dd39f70057ac5d0e897e5bfe211629652399a21671e53f2a9693a4e"},
-    {file = "regex-2021.10.23.tar.gz", hash = "sha256:f3f9a91d3cc5e5b0ddf1043c0ae5fa4852f18a1c0050318baf5fc7930ecc1f9c"},
+    {file = "regex-2021.11.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:897c539f0f3b2c3a715be651322bef2167de1cdc276b3f370ae81a3bda62df71"},
+    {file = "regex-2021.11.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:886f459db10c0f9d17c87d6594e77be915f18d343ee138e68d259eb385f044a8"},
+    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:075b0fdbaea81afcac5a39a0d1bb91de887dd0d93bf692a5dd69c430e7fc58cb"},
+    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c6238d30dcff141de076344cf7f52468de61729c2f70d776fce12f55fe8df790"},
+    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7fab29411d75c2eb48070020a40f80255936d7c31357b086e5931c107d48306e"},
+    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f0148988af0182a0a4e5020e7c168014f2c55a16d11179610f7883dd48ac0ebe"},
+    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:be30cd315db0168063a1755fa20a31119da91afa51da2907553493516e165640"},
+    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e9cec3a62d146e8e122d159ab93ac32c988e2ec0dcb1e18e9e53ff2da4fbd30c"},
+    {file = "regex-2021.11.2-cp310-cp310-win32.whl", hash = "sha256:41c66bd6750237a8ed23028a6c9173dc0c92dc24c473e771d3bfb9ee817700c3"},
+    {file = "regex-2021.11.2-cp310-cp310-win_amd64.whl", hash = "sha256:0075fe4e2c2720a685fef0f863edd67740ff78c342cf20b2a79bc19388edf5db"},
+    {file = "regex-2021.11.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:0ed3465acf8c7c10aa2e0f3d9671da410ead63b38a77283ef464cbb64275df58"},
+    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab1fea8832976ad0bebb11f652b692c328043057d35e9ebc78ab0a7a30cf9a70"},
+    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cb1e44d860345ab5d4f533b6c37565a22f403277f44c4d2d5e06c325da959883"},
+    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9486ebda015913909bc28763c6b92fcc3b5e5a67dee4674bceed112109f5dfb8"},
+    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:20605bfad484e1341b2cbfea0708e4b211d233716604846baa54b94821f487cb"},
+    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f20f9f430c33597887ba9bd76635476928e76cad2981643ca8be277b8e97aa96"},
+    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1d85ca137756d62c8138c971453cafe64741adad1f6a7e63a22a5a8abdbd19fa"},
+    {file = "regex-2021.11.2-cp36-cp36m-win32.whl", hash = "sha256:af23b9ca9a874ef0ec20e44467b8edd556c37b0f46f93abfa93752ea7c0e8d1e"},
+    {file = "regex-2021.11.2-cp36-cp36m-win_amd64.whl", hash = "sha256:070336382ca92c16c45b4066c4ba9fa83fb0bd13d5553a82e07d344df8d58a84"},
+    {file = "regex-2021.11.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:ef4e53e2fdc997d91f5b682f81f7dc9661db9a437acce28745d765d251902d85"},
+    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35ed5714467fc606551db26f80ee5d6aa1f01185586a7bccd96f179c4b974a11"},
+    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ee36d5113b6506b97f45f2e8447cb9af146e60e3f527d93013d19f6d0405f3b"},
+    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4fba661a4966adbd2c3c08d3caad6822ecb6878f5456588e2475ae23a6e47929"},
+    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77f9d16f7970791f17ecce7e7f101548314ed1ee2583d4268601f30af3170856"},
+    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f6a28e87ba69f3a4f30d775b179aac55be1ce59f55799328a0d9b6df8f16b39d"},
+    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9267e4fba27e6dd1008c4f2983cc548c98b4be4444e3e342db11296c0f45512f"},
+    {file = "regex-2021.11.2-cp37-cp37m-win32.whl", hash = "sha256:d4bfe3bc3976ccaeb4ae32f51e631964e2f0e85b2b752721b7a02de5ce3b7f27"},
+    {file = "regex-2021.11.2-cp37-cp37m-win_amd64.whl", hash = "sha256:2bb7cae741de1aa03e3dd3a7d98c304871eb155921ca1f0d7cc11f5aade913fd"},
+    {file = "regex-2021.11.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:23f93e74409c210de4de270d4bf88fb8ab736a7400f74210df63a93728cf70d6"},
+    {file = "regex-2021.11.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:d8ee91e1c295beb5c132ebd78616814de26fedba6aa8687ea460c7f5eb289b72"},
+    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e3ff69ab203b54ce5c480c3ccbe959394ea5beef6bd5ad1785457df7acea92e"},
+    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e3c00cb5c71da655e1e5161481455479b613d500dd1bd252aa01df4f037c641f"},
+    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4abf35e16f4b639daaf05a2602c1b1d47370e01babf9821306aa138924e3fe92"},
+    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb11c982a849dc22782210b01d0c1b98eb3696ce655d58a54180774e4880ac66"},
+    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07e3755e0f070bc31567dfe447a02011bfa8444239b3e9e5cca6773a22133839"},
+    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0621c90f28d17260b41838b22c81a79ff436141b322960eb49c7b3f91d1cbab6"},
+    {file = "regex-2021.11.2-cp38-cp38-win32.whl", hash = "sha256:8fbe1768feafd3d0156556677b8ff234c7bf94a8110e906b2d73506f577a3269"},
+    {file = "regex-2021.11.2-cp38-cp38-win_amd64.whl", hash = "sha256:f9ee98d658a146cb6507be720a0ce1b44f2abef8fb43c2859791d91aace17cd5"},
+    {file = "regex-2021.11.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b3794cea825f101fe0df9af8a00f9fad8e119c91e39a28636b95ee2b45b6c2e5"},
+    {file = "regex-2021.11.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3576e173e7b4f88f683b4de7db0c2af1b209bb48b2bf1c827a6f3564fad59a97"},
+    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48b4f4810117a9072a5aa70f7fea5f86fa9efbe9a798312e0a05044bd707cc33"},
+    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f5930d334c2f607711d54761956aedf8137f83f1b764b9640be21d25a976f3a4"},
+    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:956187ff49db7014ceb31e88fcacf4cf63371e6e44d209cf8816cd4a2d61e11a"},
+    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17e095f7f96a4b9f24b93c2c915f31a5201a6316618d919b0593afb070a5270e"},
+    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a56735c35a3704603d9d7b243ee06139f0837bcac2171d9ba1d638ce1df0742a"},
+    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:adf35d88d9cffc202e6046e4c32e1e11a1d0238b2fcf095c94f109e510ececea"},
+    {file = "regex-2021.11.2-cp39-cp39-win32.whl", hash = "sha256:30fe317332de0e50195665bc61a27d46e903d682f94042c36b3f88cb84bd7958"},
+    {file = "regex-2021.11.2-cp39-cp39-win_amd64.whl", hash = "sha256:85289c25f658e3260b00178757c87f033f3d4b3e40aa4abdd4dc875ff11a94fb"},
+    {file = "regex-2021.11.2.tar.gz", hash = "sha256:5e85dcfc5d0f374955015ae12c08365b565c6f1eaf36dd182476a4d8e5a1cdb7"},
 ]
 requests = [
     {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -19,6 +19,14 @@ python-dateutil = ">=2.7.0"
 typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
+name = "astor"
+version = "0.8.1"
+description = "Read/rewrite/write Python ASTs"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+
+[[package]]
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
@@ -209,6 +217,29 @@ docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=
 testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-cov", "pytest-timeout (>=1.4.2)"]
 
 [[package]]
+name = "formulaic"
+version = "0.2.4"
+description = "An implementation of Wilkinson formulas."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+astor = "*"
+interface-meta = ">=1.2"
+numpy = "*"
+pandas = "*"
+scipy = "*"
+wrapt = "*"
+
+[package.extras]
+arrow = ["pyarrow"]
+benchmarks = ["patsy", "rpy2", "uncertainties"]
+calculus = ["sympy"]
+docs = ["mkdocs-material", "pymdown-extensions", "pygments"]
+test = ["flake8", "pytest", "pytest-cov"]
+
+[[package]]
 name = "gitdb"
 version = "4.0.9"
 description = "Git Object Database"
@@ -241,7 +272,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.8.1"
+version = "4.8.2"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -254,7 +285,22 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+
+[[package]]
+name = "importlib-resources"
+version = "5.4.0"
+description = "Read resources from Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [[package]]
 name = "iniconfig"
@@ -263,6 +309,14 @@ description = "iniconfig: brain-dead simple config-ini parsing"
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "interface-meta"
+version = "1.2.4"
+description = "InterfaceMeta"
+category = "main"
+optional = false
+python-versions = ">=3.4"
 
 [[package]]
 name = "ipython-genutils"
@@ -274,7 +328,7 @@ python-versions = "*"
 
 [[package]]
 name = "jinja2"
-version = "3.0.2"
+version = "3.0.3"
 description = "A very fast and expressive template engine."
 category = "main"
 optional = false
@@ -300,7 +354,7 @@ jinja2 = "*"
 
 [[package]]
 name = "jsonschema"
-version = "4.1.2"
+version = "4.2.1"
 description = "An implementation of JSON Schema validation for Python"
 category = "main"
 optional = false
@@ -309,6 +363,7 @@ python-versions = ">=3.7"
 [package.dependencies]
 attrs = ">=17.4.0"
 importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+importlib-resources = {version = ">=1.4.0", markers = "python_version < \"3.9\""}
 pyrsistent = ">=0.14.0,<0.17.0 || >0.17.0,<0.17.1 || >0.17.1,<0.17.2 || >0.17.2"
 
 [package.extras]
@@ -439,21 +494,6 @@ optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
-name = "patsy"
-version = "0.5.2"
-description = "A Python package for describing statistical models and for building design matrices."
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-numpy = ">=1.4"
-six = "*"
-
-[package.extras]
-test = ["pytest", "pytest-cov", "scipy"]
-
-[[package]]
 name = "platformdirs"
 version = "2.4.0"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -509,36 +549,38 @@ python-versions = "*"
 
 [[package]]
 name = "py"
-version = "1.10.0"
+version = "1.11.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pybids"
-version = "0.13.2"
+version = "0.14.0"
 description = "bids: interface with datasets conforming to BIDS"
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.dependencies]
 bids-validator = "*"
 click = "*"
+formulaic = ">=0.2.4,<0.3.0"
 nibabel = ">=2.1"
 num2words = "*"
 numpy = "*"
 pandas = ">=0.23"
-patsy = "*"
 scipy = "*"
 sqlalchemy = "<1.4.0.dev0"
 
 [package.extras]
-ci_tests = ["pytest (>=3.3)", "codecov", "pytest-cov", "pytest-xdist"]
-dev = ["sphinx (>=2.2)", "numpydoc", "sphinx-rtd-theme", "pytest (>=3.3)"]
+ci_tests = ["pytest (>=3.3)", "graphviz", "codecov", "pytest-cov", "pytest-xdist"]
+dev = ["sphinx (>=2.2)", "numpydoc", "sphinx-rtd-theme", "pytest (>=3.3)", "graphviz"]
 doc = ["sphinx (>=2.2)", "numpydoc", "sphinx-rtd-theme"]
 docs = ["sphinx (>=2.2)", "numpydoc", "sphinx-rtd-theme"]
+plotting = ["graphviz"]
+plottings = ["graphviz"]
 test = ["pytest (>=3.3)"]
 tests = ["pytest (>=3.3)"]
 tutorial = ["nbconvert", "jupyter-client", "ipykernel"]
@@ -657,7 +699,7 @@ test = ["pytest (>=3.0)", "pytest-asyncio"]
 
 [[package]]
 name = "regex"
-version = "2021.11.2"
+version = "2021.11.9"
 description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
@@ -893,7 +935,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7"
-content-hash = "d009269f65da660d816193916f720eb295b6422c8cb1450af68309642f63b8a1"
+content-hash = "ac480602aa91cbc60d368e585b6d9012aa4affcc1d77b837ecc186e8f720563b"
 
 [metadata.files]
 appdirs = [
@@ -903,6 +945,10 @@ appdirs = [
 arrow = [
     {file = "arrow-1.2.1-py3-none-any.whl", hash = "sha256:6b2914ef3997d1fd7b37a71ce9dd61a6e329d09e1c7b44f4d3099ca4a5c0933e"},
     {file = "arrow-1.2.1.tar.gz", hash = "sha256:c2dde3c382d9f7e6922ce636bf0b318a7a853df40ecb383b29192e6c5cc82840"},
+]
+astor = [
+    {file = "astor-0.8.1-py2.py3-none-any.whl", hash = "sha256:070a54e890cefb5b3739d19f30f5a5ec840ffc9c50ffa7d23cc9fc1a38ebbfc5"},
+    {file = "astor-0.8.1.tar.gz", hash = "sha256:6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -993,6 +1039,10 @@ filelock = [
     {file = "filelock-3.3.2-py3-none-any.whl", hash = "sha256:bb2a1c717df74c48a2d00ed625e5a66f8572a3a30baacb7657add1d7bac4097b"},
     {file = "filelock-3.3.2.tar.gz", hash = "sha256:7afc856f74fa7006a289fd10fa840e1eebd8bbff6bffb69c26c54a0512ea8cf8"},
 ]
+formulaic = [
+    {file = "formulaic-0.2.4-py3-none-any.whl", hash = "sha256:775620d93f24f01b33a17aa2cf65a04112003c5112f12015368e4e4605a5013b"},
+    {file = "formulaic-0.2.4.tar.gz", hash = "sha256:15b71ea8972fb451f80684203cddd49620fc9ed5c2e35f31e0874e9c41910d1a"},
+]
 gitdb = [
     {file = "gitdb-4.0.9-py3-none-any.whl", hash = "sha256:8033ad4e853066ba6ca92050b9df2f89301b8fc8bf7e9324d412a63f8bf1a8fd"},
     {file = "gitdb-4.0.9.tar.gz", hash = "sha256:bac2fd45c0a1c9cf619e63a90d62bdc63892ef92387424b855792a6cabe789aa"},
@@ -1006,28 +1056,36 @@ idna = [
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.8.1-py3-none-any.whl", hash = "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15"},
-    {file = "importlib_metadata-4.8.1.tar.gz", hash = "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"},
+    {file = "importlib_metadata-4.8.2-py3-none-any.whl", hash = "sha256:53ccfd5c134223e497627b9815d5030edf77d2ed573922f7a0b8f8bb81a1c100"},
+    {file = "importlib_metadata-4.8.2.tar.gz", hash = "sha256:75bdec14c397f528724c1bfd9709d660b33a4d2e77387a3358f20b848bb5e5fb"},
+]
+importlib-resources = [
+    {file = "importlib_resources-5.4.0-py3-none-any.whl", hash = "sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45"},
+    {file = "importlib_resources-5.4.0.tar.gz", hash = "sha256:d756e2f85dd4de2ba89be0b21dba2a3bbec2e871a42a3a16719258a11f87506b"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+interface-meta = [
+    {file = "interface_meta-1.2.4-py2.py3-none-any.whl", hash = "sha256:8d11375064d51e73764a02b8225af87b1ed63c20c1df52d3867611a5e70a5fc0"},
+    {file = "interface_meta-1.2.4.tar.gz", hash = "sha256:4c7725dd4b80f97b7eecfb26023e1a8a7cdbb6d6a7207a8e93f9d4bfef9ee566"},
 ]
 ipython-genutils = [
     {file = "ipython_genutils-0.2.0-py2.py3-none-any.whl", hash = "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8"},
     {file = "ipython_genutils-0.2.0.tar.gz", hash = "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"},
 ]
 jinja2 = [
-    {file = "Jinja2-3.0.2-py3-none-any.whl", hash = "sha256:8569982d3f0889eed11dd620c706d39b60c36d6d25843961f33f77fb6bc6b20c"},
-    {file = "Jinja2-3.0.2.tar.gz", hash = "sha256:827a0e32839ab1600d4eb1c4c33ec5a8edfbc5cb42dafa13b81f182f97784b45"},
+    {file = "Jinja2-3.0.3-py3-none-any.whl", hash = "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8"},
+    {file = "Jinja2-3.0.3.tar.gz", hash = "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"},
 ]
 jinja2-time = [
     {file = "jinja2-time-0.2.0.tar.gz", hash = "sha256:d14eaa4d315e7688daa4969f616f226614350c48730bfa1692d2caebd8c90d40"},
     {file = "jinja2_time-0.2.0-py2.py3-none-any.whl", hash = "sha256:d3eab6605e3ec8b7a0863df09cc1d23714908fa61aa6986a845c20ba488b4efa"},
 ]
 jsonschema = [
-    {file = "jsonschema-4.1.2-py3-none-any.whl", hash = "sha256:166870c8ab27bd712a8627e0598de4685bd8d199c4d7bd7cacc3d941ba0c6ca0"},
-    {file = "jsonschema-4.1.2.tar.gz", hash = "sha256:5c1a282ee6b74235057421fd0f766ac5f2972f77440927f6471c9e8493632fac"},
+    {file = "jsonschema-4.2.1-py3-none-any.whl", hash = "sha256:2a0f162822a64d95287990481b45d82f096e99721c86534f48201b64ebca6e8c"},
+    {file = "jsonschema-4.2.1.tar.gz", hash = "sha256:390713469ae64b8a58698bb3cbc3859abe6925b565a973f87323ef21b09a27a8"},
 ]
 jupyter-core = [
     {file = "jupyter_core-4.9.1-py3-none-any.whl", hash = "sha256:1c091f3bbefd6f2a8782f2c1db662ca8478ac240e962ae2c66f0b87c818154ea"},
@@ -1184,10 +1242,6 @@ pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
 ]
-patsy = [
-    {file = "patsy-0.5.2-py2.py3-none-any.whl", hash = "sha256:cc80955ae8c13a7e7c4051eda7b277c8f909f50bc7d73e124bc38e2ee3d95041"},
-    {file = "patsy-0.5.2.tar.gz", hash = "sha256:5053de7804676aba62783dbb0f23a2b3d74e35e5bfa238b88b7cbf148a38b69d"},
-]
 platformdirs = [
     {file = "platformdirs-2.4.0-py3-none-any.whl", hash = "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"},
     {file = "platformdirs-2.4.0.tar.gz", hash = "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2"},
@@ -1235,12 +1289,12 @@ pulp = [
     {file = "PuLP-2.5.1.tar.gz", hash = "sha256:27c2a87a98ea0e9a08c7c46e6df47d6d4e753ad9991fea2901892425d89c99a6"},
 ]
 py = [
-    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
-    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 pybids = [
-    {file = "pybids-0.13.2-py3-none-any.whl", hash = "sha256:2b34939e7c147ee557d66699bfac3a74a34db53d27b2b7e12cf8a3556f7282c3"},
-    {file = "pybids-0.13.2.tar.gz", hash = "sha256:9692013af3b86b096b5423b88179c6c9b604baff5a6b6f89ba5f40429feb7a3e"},
+    {file = "pybids-0.14.0-py3-none-any.whl", hash = "sha256:65e80a6b2dacf6a3964ceef88a6a5ac4fb076ff661382bc68fd153ebce83e324"},
+    {file = "pybids-0.14.0.tar.gz", hash = "sha256:73c4d03aad333f2a7cb4405abe96f55a33cffa4b5a2d23fad6ac5767c45562ef"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
@@ -1341,55 +1395,55 @@ ratelimiter = [
     {file = "ratelimiter-1.2.0.post0.tar.gz", hash = "sha256:5c395dcabdbbde2e5178ef3f89b568a3066454a6ddc223b76473dac22f89b4f7"},
 ]
 regex = [
-    {file = "regex-2021.11.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:897c539f0f3b2c3a715be651322bef2167de1cdc276b3f370ae81a3bda62df71"},
-    {file = "regex-2021.11.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:886f459db10c0f9d17c87d6594e77be915f18d343ee138e68d259eb385f044a8"},
-    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:075b0fdbaea81afcac5a39a0d1bb91de887dd0d93bf692a5dd69c430e7fc58cb"},
-    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c6238d30dcff141de076344cf7f52468de61729c2f70d776fce12f55fe8df790"},
-    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7fab29411d75c2eb48070020a40f80255936d7c31357b086e5931c107d48306e"},
-    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f0148988af0182a0a4e5020e7c168014f2c55a16d11179610f7883dd48ac0ebe"},
-    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:be30cd315db0168063a1755fa20a31119da91afa51da2907553493516e165640"},
-    {file = "regex-2021.11.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e9cec3a62d146e8e122d159ab93ac32c988e2ec0dcb1e18e9e53ff2da4fbd30c"},
-    {file = "regex-2021.11.2-cp310-cp310-win32.whl", hash = "sha256:41c66bd6750237a8ed23028a6c9173dc0c92dc24c473e771d3bfb9ee817700c3"},
-    {file = "regex-2021.11.2-cp310-cp310-win_amd64.whl", hash = "sha256:0075fe4e2c2720a685fef0f863edd67740ff78c342cf20b2a79bc19388edf5db"},
-    {file = "regex-2021.11.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:0ed3465acf8c7c10aa2e0f3d9671da410ead63b38a77283ef464cbb64275df58"},
-    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab1fea8832976ad0bebb11f652b692c328043057d35e9ebc78ab0a7a30cf9a70"},
-    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cb1e44d860345ab5d4f533b6c37565a22f403277f44c4d2d5e06c325da959883"},
-    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9486ebda015913909bc28763c6b92fcc3b5e5a67dee4674bceed112109f5dfb8"},
-    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:20605bfad484e1341b2cbfea0708e4b211d233716604846baa54b94821f487cb"},
-    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f20f9f430c33597887ba9bd76635476928e76cad2981643ca8be277b8e97aa96"},
-    {file = "regex-2021.11.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1d85ca137756d62c8138c971453cafe64741adad1f6a7e63a22a5a8abdbd19fa"},
-    {file = "regex-2021.11.2-cp36-cp36m-win32.whl", hash = "sha256:af23b9ca9a874ef0ec20e44467b8edd556c37b0f46f93abfa93752ea7c0e8d1e"},
-    {file = "regex-2021.11.2-cp36-cp36m-win_amd64.whl", hash = "sha256:070336382ca92c16c45b4066c4ba9fa83fb0bd13d5553a82e07d344df8d58a84"},
-    {file = "regex-2021.11.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:ef4e53e2fdc997d91f5b682f81f7dc9661db9a437acce28745d765d251902d85"},
-    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35ed5714467fc606551db26f80ee5d6aa1f01185586a7bccd96f179c4b974a11"},
-    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ee36d5113b6506b97f45f2e8447cb9af146e60e3f527d93013d19f6d0405f3b"},
-    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4fba661a4966adbd2c3c08d3caad6822ecb6878f5456588e2475ae23a6e47929"},
-    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77f9d16f7970791f17ecce7e7f101548314ed1ee2583d4268601f30af3170856"},
-    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f6a28e87ba69f3a4f30d775b179aac55be1ce59f55799328a0d9b6df8f16b39d"},
-    {file = "regex-2021.11.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9267e4fba27e6dd1008c4f2983cc548c98b4be4444e3e342db11296c0f45512f"},
-    {file = "regex-2021.11.2-cp37-cp37m-win32.whl", hash = "sha256:d4bfe3bc3976ccaeb4ae32f51e631964e2f0e85b2b752721b7a02de5ce3b7f27"},
-    {file = "regex-2021.11.2-cp37-cp37m-win_amd64.whl", hash = "sha256:2bb7cae741de1aa03e3dd3a7d98c304871eb155921ca1f0d7cc11f5aade913fd"},
-    {file = "regex-2021.11.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:23f93e74409c210de4de270d4bf88fb8ab736a7400f74210df63a93728cf70d6"},
-    {file = "regex-2021.11.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:d8ee91e1c295beb5c132ebd78616814de26fedba6aa8687ea460c7f5eb289b72"},
-    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e3ff69ab203b54ce5c480c3ccbe959394ea5beef6bd5ad1785457df7acea92e"},
-    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e3c00cb5c71da655e1e5161481455479b613d500dd1bd252aa01df4f037c641f"},
-    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4abf35e16f4b639daaf05a2602c1b1d47370e01babf9821306aa138924e3fe92"},
-    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb11c982a849dc22782210b01d0c1b98eb3696ce655d58a54180774e4880ac66"},
-    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07e3755e0f070bc31567dfe447a02011bfa8444239b3e9e5cca6773a22133839"},
-    {file = "regex-2021.11.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0621c90f28d17260b41838b22c81a79ff436141b322960eb49c7b3f91d1cbab6"},
-    {file = "regex-2021.11.2-cp38-cp38-win32.whl", hash = "sha256:8fbe1768feafd3d0156556677b8ff234c7bf94a8110e906b2d73506f577a3269"},
-    {file = "regex-2021.11.2-cp38-cp38-win_amd64.whl", hash = "sha256:f9ee98d658a146cb6507be720a0ce1b44f2abef8fb43c2859791d91aace17cd5"},
-    {file = "regex-2021.11.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b3794cea825f101fe0df9af8a00f9fad8e119c91e39a28636b95ee2b45b6c2e5"},
-    {file = "regex-2021.11.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3576e173e7b4f88f683b4de7db0c2af1b209bb48b2bf1c827a6f3564fad59a97"},
-    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48b4f4810117a9072a5aa70f7fea5f86fa9efbe9a798312e0a05044bd707cc33"},
-    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f5930d334c2f607711d54761956aedf8137f83f1b764b9640be21d25a976f3a4"},
-    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:956187ff49db7014ceb31e88fcacf4cf63371e6e44d209cf8816cd4a2d61e11a"},
-    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17e095f7f96a4b9f24b93c2c915f31a5201a6316618d919b0593afb070a5270e"},
-    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a56735c35a3704603d9d7b243ee06139f0837bcac2171d9ba1d638ce1df0742a"},
-    {file = "regex-2021.11.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:adf35d88d9cffc202e6046e4c32e1e11a1d0238b2fcf095c94f109e510ececea"},
-    {file = "regex-2021.11.2-cp39-cp39-win32.whl", hash = "sha256:30fe317332de0e50195665bc61a27d46e903d682f94042c36b3f88cb84bd7958"},
-    {file = "regex-2021.11.2-cp39-cp39-win_amd64.whl", hash = "sha256:85289c25f658e3260b00178757c87f033f3d4b3e40aa4abdd4dc875ff11a94fb"},
-    {file = "regex-2021.11.2.tar.gz", hash = "sha256:5e85dcfc5d0f374955015ae12c08365b565c6f1eaf36dd182476a4d8e5a1cdb7"},
+    {file = "regex-2021.11.9-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:03248f5a7831c7dfd8f4806115e2cc034c5caf90a54c5ede643e10369b656c52"},
+    {file = "regex-2021.11.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:55315f5b7b51034584b70bc90595957e66c9c28acc0d947ab9e03db73788f328"},
+    {file = "regex-2021.11.9-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b37e60e25564f6c407933cf60836b67f5351233c3f2f26b8f7a6415dc96f04f7"},
+    {file = "regex-2021.11.9-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6d2ec8751d43b02905195302fd759595a00aa0865c6d811dedafafc1aa6564c9"},
+    {file = "regex-2021.11.9-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:872fbe9363ac94a84bfee8c417c47fd66225b427c830aa7bcbd6b6a7d129780e"},
+    {file = "regex-2021.11.9-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6be76a690c3dfae0c1bd6b880475897fca565f85a00946ef8955c73e6a9ba0b"},
+    {file = "regex-2021.11.9-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:546167b64c7679bd247c43be665df0993241ee529e902edfd7fc4f7fc43fa859"},
+    {file = "regex-2021.11.9-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5ae92b925ca6a63bf40666d63f674452eed83684fde2346e02671b9825139e67"},
+    {file = "regex-2021.11.9-cp310-cp310-win32.whl", hash = "sha256:ef109a3be5e317fe105907177e2ffbe5ecb343a8f04f89d949aaa716019c740b"},
+    {file = "regex-2021.11.9-cp310-cp310-win_amd64.whl", hash = "sha256:ddbab7617ea6d64028e0cd431ef1ade6043edae8c991b9340a49ee3b3fe3dcc0"},
+    {file = "regex-2021.11.9-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:52a681f3bf97f7b2284b3e70876899d56289d3d4f33da970bc1ac775ca95ad5b"},
+    {file = "regex-2021.11.9-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b4dc0bacdf01b3a8e493ba6d58fc1bae2a12664af56bc75b704a5a8af0f1c09"},
+    {file = "regex-2021.11.9-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:03a8c698aa4eaa26bcebd94676db345206677422a32b6269bd67502291b3f5a4"},
+    {file = "regex-2021.11.9-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9bd530355e16bf4b98a62f54110fdddb3317df45427edc21f1d0252fd951b842"},
+    {file = "regex-2021.11.9-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f0254e03b091132f5bac8b1a977b6084694356c8b5ce8144f1ca283ec106792a"},
+    {file = "regex-2021.11.9-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9b036a0ece4ca8b7ffe6edeb2db06f041eadbe0cc80d8b8f671aececd0ea1bfb"},
+    {file = "regex-2021.11.9-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:63b60bedf3f13c725277cfbcef4ff6fda45d17197091dff4c1480f686485efa2"},
+    {file = "regex-2021.11.9-cp36-cp36m-win32.whl", hash = "sha256:045d5208cb78cde5a3eec57f4792d2bce8cb591a3aa00897973a44d53a72cb54"},
+    {file = "regex-2021.11.9-cp36-cp36m-win_amd64.whl", hash = "sha256:ca5226d0c9aa96678df8aff72ad39b6cfc433ba98ad19617074ac7d76e0b0818"},
+    {file = "regex-2021.11.9-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:f45d669c75451c8c9f8309a5e1294f9386911b287a544d4f286f4911bb07408c"},
+    {file = "regex-2021.11.9-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15c74124502d75dd3e625879441981e4c00ef7b256ea5312edeef236943fe260"},
+    {file = "regex-2021.11.9-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f3ce348049e6ed09c0d5f79634501c2f0f888f381034107f3ec9b64c2f0da6d1"},
+    {file = "regex-2021.11.9-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0bd28cbb1ec25dacdf90773f9d67a2bf8d5e28a1174334b4051e8316624dc6ad"},
+    {file = "regex-2021.11.9-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d9cb902c00f66ae8e070f0734826f6d22e9f66089cfdf1fbed0cb7227b114c66"},
+    {file = "regex-2021.11.9-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ee60b70e19e61c4772418349bc28c1b81f1e7de47f710f457fb4bea0b616a4b3"},
+    {file = "regex-2021.11.9-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:107032d37826480a8be6d986d26f714ea1e5d7bd42940ce0275ac3cddb2f242b"},
+    {file = "regex-2021.11.9-cp37-cp37m-win32.whl", hash = "sha256:0c4b7b5c3d604f3fda1d8a3a70cfa94471ff0f15c87cb31aea1d1ac6009b84f6"},
+    {file = "regex-2021.11.9-cp37-cp37m-win_amd64.whl", hash = "sha256:90a2bf9770e3f964a61aa62b24e7f1d328d8a1e020b81240ab7d908ab54aa218"},
+    {file = "regex-2021.11.9-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6ffd0122ef77c41dc87da03feac5105532e4b4ea07e91d4da80f64d033a6328d"},
+    {file = "regex-2021.11.9-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:050a0cd770946666cf2f596e591d4e31ce40831c722fa81cdc77098248788fd8"},
+    {file = "regex-2021.11.9-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:70a43db5faf490c0f14cb3dce6c56c2895a8adcdffc8a9bf21264105f321ac5b"},
+    {file = "regex-2021.11.9-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e93f50833189cb6b83aaaac557d358ca0d3d7ae5963bee1e352c235affcb2cf5"},
+    {file = "regex-2021.11.9-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:019b20a3abbcbad704172f8bb168e08774e86ef422a2e5921aad27fa3597662a"},
+    {file = "regex-2021.11.9-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:363c744622796f4018be80fcba705de9061df9ad2b67eb74227be25bc1d757ff"},
+    {file = "regex-2021.11.9-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d7bedd6aff103c6f0cf2c7bc6e5504008f2d1e4c55b3e95b8bad514f1ddb85aa"},
+    {file = "regex-2021.11.9-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9e9f3ded639a0f8033f2b1ea819f9eb42218212176f3590dcaeef884f3f9c8c8"},
+    {file = "regex-2021.11.9-cp38-cp38-win32.whl", hash = "sha256:51d9dac6382992dd7ca8f05a95cb15635dc25141250f152b1844460cd4dc2000"},
+    {file = "regex-2021.11.9-cp38-cp38-win_amd64.whl", hash = "sha256:e84ba3c37f2f00f0cc207d8c32c06a557fe39eda90ee2e8b0e952bc81f6ac4a4"},
+    {file = "regex-2021.11.9-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:00a3e774de2c1f20006ee440eaab61c5ee3bcc5abc99e671a6b6069886c1e667"},
+    {file = "regex-2021.11.9-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6df323051b17539c6256978b6414f90e06e8e9148743eba747f7a7d21a609c17"},
+    {file = "regex-2021.11.9-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e85e14e408b50bb0ebfd2ba1949055e2940863e4ce84641d58df384c42120e79"},
+    {file = "regex-2021.11.9-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:635e0dd3fff4b8583578c35821107ad99c17d96de4ba6c7a3ac8a600a49c7bbe"},
+    {file = "regex-2021.11.9-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6e9ce3b19d9a9260b68f9654b39d493df79c44752f1a7a1274afefa03919736e"},
+    {file = "regex-2021.11.9-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b2e961ecdea069a40e481613c545679e0d09af56c8913263c519393367449a52"},
+    {file = "regex-2021.11.9-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fb0d986bf28e3841f8c618b296cb8f94628d6b0f330bd7208300b5b439a6d08"},
+    {file = "regex-2021.11.9-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:aabd4b197aa3ba60144ce5eef6f320d30641b7085535bbe0e8c29458ab5c910a"},
+    {file = "regex-2021.11.9-cp39-cp39-win32.whl", hash = "sha256:b0870a30090f3674eabf28457048033871e8d7695c25efe90aa755fc987e3658"},
+    {file = "regex-2021.11.9-cp39-cp39-win_amd64.whl", hash = "sha256:cfacb18b4c8b9adbe50aafe5b903bf8283c48106b9696ec68a185029a6f0d071"},
+    {file = "regex-2021.11.9.tar.gz", hash = "sha256:983f0953523e763931197a8a966b6d9ca21834a57ff5316d2938aa26b5b1f5e2"},
 ]
 requests = [
     {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "snakebids"
-version = "0.3.16"
+version = "0.4.0-alpha.0"
 description = "BIDS integration into snakemake workflows"
 readme = "README.rst"
 repository = "https://github.com/akhanf/snakebids"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ snakemake = ">=5.28.0"
 PyYAML = ">=5.3.1"
 cookiecutter = ">=1.7.2"
 colorama = "^0.4.4"
+typing-extensions = "^3.10.0"
 
 [tool.poetry.dev-dependencies]
 black = "^21.10b0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,11 @@ pybids = ">=0.13.2"
 snakemake = ">=5.28.0"
 PyYAML = ">=5.3.1"
 cookiecutter = ">=1.7.2"
+colorama = "^0.4.4"
 
 [tool.poetry.dev-dependencies]
 black = "^21.10b0"
 pytest = "^6.2.5"
-ConfigArgParse = "^1.5.3"
 pytest-mock = "^3.6.1"
 
 [tool.poetry.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ PyYAML = ">=5.3.1"
 cookiecutter = ">=1.7.2"
 colorama = "^0.4.4"
 typing-extensions = "^3.10.0"
+progress = "^1.6"
 
 [tool.poetry.dev-dependencies]
 black = "^21.10b0"

--- a/snakebids/__init__.py
+++ b/snakebids/__init__.py
@@ -10,10 +10,10 @@ import logging
 
 from bids import BIDSLayout, BIDSLayoutIndexer
 import bids as pybids
-
+from bids import config as bidsconfig
 from snakebids.snakemake_io import glob_wildcards
 
-pybids.config.set_option("extension_initial_dot", True)
+bidsconfig.set_option("extension_initial_dot", True)
 logger = logging.getLogger(__name__)
 
 

--- a/snakebids/__init__.py
+++ b/snakebids/__init__.py
@@ -459,7 +459,7 @@ def get_filtered_ziplist_index(zip_list, wildcards, subj_wildcards):
     return indices
 
 
-def __read_bids_tags(bids_json=None):
+def _read_bids_tags(bids_json=None):
     """Read the bids tags we are aware of from a JSON file. This is used
     specifically for compatibility with pybids, since some tag keys are
     different from how they appear in the file name, e.g. ``subject`` for
@@ -482,7 +482,7 @@ def __read_bids_tags(bids_json=None):
     return bids_tags
 
 
-def __generate_search_terms(
+def _generate_search_terms(
     participant_label=None, exclude_participant_label=None
 ):
     search_terms = {}
@@ -664,7 +664,7 @@ def generate_inputs(
         }
     """
 
-    search_terms = __generate_search_terms(
+    search_terms = _generate_search_terms(
         participant_label, exclude_participant_label
     )
 
@@ -685,7 +685,7 @@ def generate_inputs(
 
     # this will populate input_path, input_lists, input_zip_lists, and
     # input_wildcards
-    inputs_config_dict = __get_lists_from_bids(
+    inputs_config_dict = _get_lists_from_bids(
         bids_layout=layout,
         pybids_inputs=pybids_inputs,
         limit_to=limit_to,
@@ -741,7 +741,7 @@ def generate_inputs(
     return inputs_config_dict
 
 
-def __process_path_override(input_path):
+def _process_path_override(input_path):
     """Glob wildcards from a path override and arrange into a zip list of
     matches, list of matches, and Snakemake wildcard for each wildcard.
     """
@@ -765,7 +765,7 @@ def __process_path_override(input_path):
     return input_zip_lists, input_lists, input_wildcards
 
 
-def __process_layout_wildcard(path, wildcard_name):
+def _process_layout_wildcard(path, wildcard_name):
     """Convert an absolute BIDS path to the same path with the given tag
     replaced by a wildcard.
 
@@ -787,7 +787,7 @@ def __process_layout_wildcard(path, wildcard_name):
     out_name : str
         Name of the applied wildcard (e.g. "subject")
     """
-    bids_tags = __read_bids_tags()
+    bids_tags = _read_bids_tags()
     tag = (
         bids_tags[wildcard_name]
         if wildcard_name in bids_tags
@@ -831,7 +831,7 @@ def __process_layout_wildcard(path, wildcard_name):
     return path, match[1], out_name
 
 
-def __get_lists_from_bids(
+def _get_lists_from_bids(
     bids_layout, pybids_inputs, limit_to=None, **filters
 ):
     """Grabs files using pybids and creates snakemake-friendly lists
@@ -903,7 +903,7 @@ def __get_lists_from_bids(
                 input_zip_lists,
                 input_lists,
                 input_wildcards,
-            ) = __process_path_override(input_path)
+            ) = _process_path_override(input_path)
         else:
             paths = set()
             for img in bids_layout.get(
@@ -923,7 +923,7 @@ def __get_lists_from_bids(
                         input_path,
                         input_list,
                         out_name,
-                    ) = __process_layout_wildcard(input_path, wildcard_name)
+                    ) = _process_layout_wildcard(input_path, wildcard_name)
                     if out_name not in input_zip_lists:
                         input_zip_lists[out_name] = []
                         input_lists[out_name] = set()

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -481,6 +481,7 @@ class SnakeBidsApp:
         else:
             new_config_file = self.outputdir/"code"/Path(self.configfile_path).name
             cwd = self.snakemake_dir
+            force_config_overwrite = True
 
         write_config_file(new_config_file, self.config, force_config_overwrite)
 

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -13,6 +13,8 @@ import bids
 import snakemake
 from snakemake.io import load_configfile
 
+from snakebids.exceptions import ConfigError
+
 # We define Path here in addition to pathlib to put both variables in globals()
 # This way, users specifying a path type in their config.yaml can indicate
 # either Path or pathlib.Path
@@ -22,12 +24,6 @@ bids.config.set_option("extension_initial_dot", True)
 logger = logging.Logger(__name__)
 
 
-class ConfigError(Exception):
-    """Exception raised for errors with the Snakebids config."""
-
-    def __init__(self, msg):
-        self.msg = msg
-        Exception.__init__()
 
 
 class KeyValue(argparse.Action):

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -214,16 +214,16 @@ class SnakeBidsApp:
         self.config["snakemake_dir"] = snakemake_dir
         self.config["snakefile"] = self.snakefile
 
-        self.parser_include_snakemake = self.__create_parser(
+        self.parser_include_snakemake = self._create_parser(
             include_snakemake=True
         )
-        self.parser = self.__create_parser()
+        self.parser = self._create_parser()
 
         if not skip_parse_args:
-            self.__parse_args()
+            self._parse_args()
 
 
-    def __create_parser(self, include_snakemake=False):
+    def _create_parser(self, include_snakemake=False):
         """Create a parser with snakemake parser as parent solely for
         displaying help and checking conflicts, but then for actual parsing
         use snakebids parser to parse known args, then pass remaining to
@@ -341,7 +341,7 @@ class SnakeBidsApp:
 
         return parser
 
-    def __parse_args(self):
+    def _parse_args(self):
 
         # use snakebids parser to parse the known arguments
         # will pass the rest of args when running snakemake

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -475,13 +475,14 @@ class SnakeBidsApp:
 
         if mode == "workflow":
             self.config["output_dir"] = str(root)
+            self.config["root"] = 'results'
             new_config_file = self.outputdir/self.configfile_path
-            
-            cwd = self.outputdir
         else:
-            new_config_file = self.outputdir/"code"/Path(self.configfile_path).name
-            cwd = self.snakemake_dir
             force_config_overwrite = True
+            self.config["root"] = ''
+            new_config_file = self.outputdir/'code'/Path(self.configfile_path).name
+        
+        cwd = self.outputdir
 
         write_config_file(new_config_file, self.config, force_config_overwrite)
 

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """Tools to generate a Snakemake-based BIDS app."""
 
 import os
@@ -13,6 +11,7 @@ import bids
 import snakemake
 from snakemake.io import load_configfile
 
+from bids import config as bidsconfig
 from snakebids.exceptions import ConfigError
 
 # We define Path here in addition to pathlib to put both variables in globals()
@@ -20,7 +19,7 @@ from snakebids.exceptions import ConfigError
 # either Path or pathlib.Path
 Path = pathlib.Path
 
-bids.config.set_option("extension_initial_dot", True)
+bidsconfig.set_option("extension_initial_dot", True)
 logger = logging.Logger(__name__)
 
 

--- a/snakebids/exceptions.py
+++ b/snakebids/exceptions.py
@@ -7,3 +7,6 @@ class ConfigError(Exception):
 
 class RunError(Exception):
     """Exception raised for errors in generating and running the snakemake workflow."""
+    def __init__(self, msg: str, *args: object) -> None:
+        super().__init__(*args)
+        self.msg = msg

--- a/snakebids/exceptions.py
+++ b/snakebids/exceptions.py
@@ -1,0 +1,6 @@
+class ConfigError(Exception):
+    """Exception raised for errors with the Snakebids config."""
+
+    def __init__(self, msg):
+        self.msg = msg
+        super().__init__()

--- a/snakebids/exceptions.py
+++ b/snakebids/exceptions.py
@@ -4,3 +4,6 @@ class ConfigError(Exception):
     def __init__(self, msg):
         self.msg = msg
         super().__init__()
+
+class RunError(Exception):
+    """Exception raised for errors in generating and running the snakemake workflow."""

--- a/snakebids/output.py
+++ b/snakebids/output.py
@@ -1,0 +1,489 @@
+"""Tools to manage generation and interconversion of bidsapps and snakemake outputs."""
+
+import itertools as it
+import json
+from pathlib import Path, PosixPath, WindowsPath
+import shutil
+import os
+from typing import Iterable, List, Union
+
+from colorama import Fore
+from typing_extensions import Literal
+import yaml
+
+from snakebids.exceptions import RunError
+
+
+Mode = Union[Literal["workflow"], Literal["bidsapp"]]
+
+
+def prepare_output(
+    src: Path,
+    outputdir: Path,
+    mode: Mode,
+    force_conversion: bool = False
+):
+    """Ensure output directory is in the correct mode and is ready for snakemake to run
+    
+    Checks for existing output at the directory, converting to the appropriate mode if
+    necessary. If running in workflow mode, the src snakemake directory is copied over
+    to the output, and snakemake output will be put in results. In bidsapp mode, the
+    snakemake results will be put in the top level of the output directory without any
+    extra snakemake files. Creates a .snakebids file to track output mode and other
+    workflow information. Raises exceptions when attempting to convert from workflow
+    mode to bidsapp mode without force, when the output directory already has contents
+    but no .snakebids file to identify it, or when attempting to convert snakemake
+    results that, themselves, have a results folder
+
+    Parameters
+    ----------
+    src : Path
+        Path to snakebids app
+    outputdir : Path
+        Path to output
+    mode : "bidsapp" or "workflow"
+        Mode in which to run
+    force_conversion : bool
+        Force conversion from workflow to bidsapp
+        mode. Defaults to False.
+    src: Path :
+        
+    outputdir: Path :
+        
+    mode: Mode :
+        
+    force_conversion: bool :
+         (Default value = False)
+
+    Returns
+    -------
+    Path
+        Path to new root folder (output for bidsapp, output/results for workflow)
+
+    Raises
+    ------
+    RunError
+        Raised when attempting to convert from workflow mode to bidsapp mode
+        without force, when the output directory already has contents but no
+        .snakebids file to identify it, or when attempting to convert snakemake
+        results that, themselves, have a results folder
+
+    """
+    if mode not in ["workflow", "bidsapp"]:
+        raise RunError(
+            f"Requested unsupported output mode: {mode}.\n"
+            "Please select between \"workflow\" and \"bidsapp\""
+        )
+
+    # Look for .snakebids file. If the outputdir doesn't yet exist, we'll get None.
+    # If it does exist but there's no .snakebids file, an error will be raised.
+    snakebids_file = _get_snakebids_file(outputdir)
+    outputdir.mkdir(exist_ok=True)
+    
+    if not snakebids_file:
+        write_output_mode(outputdir / ".snakebids", mode)
+    
+        if mode == "bidsapp":
+            return outputdir
+
+        return _copy_snakemake_app(src, outputdir)
+
+    
+    with snakebids_file.open("r") as f:
+        snakebids_data = json.load(f)
+    root = _convert_output(
+        snakebids_data["mode"],
+        mode,
+        src,
+        outputdir,
+        force_conversion
+    )
+    write_output_mode(outputdir / ".snakebids", mode)
+    return root
+
+
+def write_output_mode(dotfile: Path, mode: Mode):
+    """Write output mode to .snakebids
+
+    Parameters
+    ----------
+    dotfile: Path
+        Path to .snakebids file to be written
+    mode: Mode
+        Mode to write: either "bidsapp" or "workflow"
+    """
+    if dotfile.exists():
+        with dotfile.open('r') as f:
+            data = json.load(f)
+    else:
+        data = {}
+    data["mode"] = mode
+    with (dotfile).open("w") as f:
+        json.dump(data, f)
+
+
+def retrofit_output(output: Path, config_files: Iterable[Path]):
+    """Convert legacy snakebids output to bidsapp mode.
+
+    Expects a directory containing previous snakebids outpus. This should contain one or
+    more config files, as specified in the config_files parameter. If a config directory
+    resides in the output, it should only contain specified config files. If extra files
+    are found, an error will be thrown. All config files will be deleted, and a new
+    .snakebids file will be created.
+
+    Parameters
+    ----------
+    output : Path
+        Path of output directory to be modified
+    config_files : Iterable[Path]
+        List of paths of config files.
+
+    Returns
+    -------
+    boolean
+        Returns True if successful, False if User declined operation in interactive
+        prompt
+
+    Raises
+    ------
+    RunError
+        Raised if existing .snakebids file found, if unrecognized files are found in the
+        config folder, or if no config files are provided.
+    """
+    config_files = [*config_files]
+    if (output/".snakebids").exists():
+        raise RunError(
+            f".snakebids file already found at {output}"
+        )
+    if not config_files:
+        raise RunError(
+            f"No config files found in {output}. Cannot perform retrofit."
+        )
+    if (output/"config").exists() and (output/"config").is_dir():
+        to_delete = it.chain(config_files, [output/"config"])
+        unknown_files = {*(output/"config").iterdir()} - {*config_files}
+        if len(unknown_files) > 0:
+            raise RunError(
+                f"Unrecognized files found in config folder ({output/'config'}",
+                _format_path_list(unknown_files)
+            )
+    else:
+        to_delete = config_files
+
+    print(
+        f"Converting {output} into bidsapp format.\n"
+    )
+
+    if not _remove_all(to_delete, confirm=True):
+        return False
+    write_output_mode(output/".snakebids", "bidsapp")
+    return True
+
+
+def _convert_output(start: Mode, end: Mode, src: Path, output: Path, force=False):
+    """Convert existing output between bidsapp and workflow mode
+    
+    Does nothing if start and end are the same. Because of the potential loss of
+    information (all the workflow files), this will only convert from bidsapp to
+    workflow mode if force is True, otherwise it raises an exception. Returns the
+    root folder of the converted dataset (ouput if bidsapp mode, results if workflow)
+
+    Parameters
+    ----------
+    start : "bidsapp" or "workflow"
+        Current format of the output
+    end : "bidsapp" or "workflow"
+        Desired format of the output
+    src : Path
+        Path to the snakebids app being run
+    output : Path
+        Output to transform
+    force : bool
+        Force conversions from workflow to bidsapp mode.
+        Defaults to False.
+
+    Returns
+    -------
+    Path
+        Path to the root folder (output/results if workflow, output if bidsapp)
+
+    Raises
+    ------
+    RunError
+        Raised if conversion from workflow to bidsapp attempted without force
+
+    """
+    if start == end:
+        if end == "workflow":
+            return output/"results"
+        return output
+    
+    # Convert to workflow mode
+    if end == "workflow":
+        results = _check_for_results_folder(output)
+        results.mkdir()
+        [shutil.move(f, results / f.name) for f in output.iterdir() if f != results]
+
+        # Move .snakebids file back to the top level
+        shutil.move(results / ".snakebids", output / ".snakebids")
+        _copy_snakemake_app(src, output, False)
+        return results
+    
+    # Convert to Bidsapp mode
+    if not force:
+        raise RunError(
+            f"You are attempting to convert a preexisting output ({output}) "
+            "from workflow mode to bidsapp mode. This will result in the loss "
+            "of all workflow files and custom configs. If you are sure you "
+            "wish to do this, run this command again with --force-conversion. " 
+            "Otherwise, run the command with --workflow-mode to maintain the current "
+            "output mode."
+        )
+    # Check if results folder/file exists within the results folder. We don't 
+    # need its output, just its exception.
+    _check_for_results_folder(output / "results")
+
+    # Delete everything in the output folder except for .snakebids and results
+    _remove_all(f for f in output.iterdir() if f not in [
+        output/".snakebids",
+        output/"results"
+    ])            
+    
+    [shutil.move(f, output / f.name) for f in (output/"results").iterdir()]
+    (output/"results").rmdir()
+    return output
+
+
+def _remove_all(paths: Iterable[Path], confirm: bool = False):
+    if confirm:
+        paths = [*paths]
+        print(
+            f"\t{Fore.YELLOW}The following files and folders will be DELETED:\n{Fore.RESET}",
+            _format_path_list(paths)
+        )
+        user_response = input("Would you like to continue? [yes,NO]")
+        if user_response.lower() != "yes":
+            return False
+
+    dirs: List[Path] = []
+    for f in paths:
+        if f.is_dir(): dirs.append(f)
+        if f.is_symlink(): f.unlink()
+        if f.is_file(): os.remove(f)
+    for d in dirs:
+        shutil.rmtree(d)
+    return True
+
+
+def _format_path_list(paths: Iterable[Path]):
+    return '\t\t- ' + '\n\t\t- '.join(str(p) for p in paths)
+
+def _copy_snakemake_app(src: Path, dest: Path, create_results: bool = True):
+    """Copies snakemap app from src to dest, skipping the config and results directories
+    
+    Creates an empty results and config folder, and returns the path to the results
+    folder.
+
+    Parameters
+    ----------
+    src : Path
+        Directory to copy from
+    dest : Path
+        Directroy to copy to
+    create_results: bool
+        If True, create an empty results folder (Default value = True)
+
+    Returns
+    -------
+    Path
+        Path of results folder in new snakemake location
+
+    """
+    # shutils.copytree makes it hard to exclude just root level folders, so we do this
+    # manually
+    old_cwd = Path().cwd()
+    os.chdir(src)
+    file_list = [*it.chain(
+        # All root level files and symlinks
+        [f for f in Path().iterdir() if not f.is_dir() and f != Path()/".snakebids"],
+        # Recursive search through all directories
+        *[
+            f.glob("**/*") for f in Path().iterdir() if f not in [
+                Path() / "config",
+                Path() / "results",
+            ]
+        ]
+    )]
+
+    relative_symlink_paths = {
+        # Get set of paths for all symlinks pointing to paths within the
+        # file_list. First, find the set of all symlink paths:
+        f.resolve() for f in file_list if f.is_symlink()
+    } & {
+        # Then get its union with the set of all potential symlink targets (e.g files
+        # and directories)
+        f.resolve() for f in file_list if not f.is_symlink()
+    }
+    
+    # Iterate through files
+    links = []
+    for file in file_list:
+        if file.is_symlink():
+            # If the object is a symlink pointing to something else that we copied, save
+            # it for after the loop
+            if file.resolve() in relative_symlink_paths:
+                links.append(file)
+            # Otherwise go ahead and move it now
+            else:
+                shutil.copy(file, dest/file, follow_symlinks=False) 
+
+        # Copy over files, making parents as necessary
+        elif file.is_file():
+            (dest/file).parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(file, dest/file)
+
+    # Loop through our collected symlinks and relink
+    for link in links:
+        dest_link = dest/link.resolve().relative_to(src)
+        (dest/link).symlink_to(dest_link)
+
+    os.chdir(old_cwd)
+    if create_results: (dest/"results").mkdir()
+    (dest/"config").mkdir()
+    return dest/"results"
+
+def _get_snakebids_file(outputdir: Path):
+    """Ensure populated dir contains .snakebids file, retrieving it if it does.
+    
+    First checks if outpdir doesn't exist or is completely empty, returing None if so.
+    If it does have data, it checks for a .snakebids file, returning its Path if found.
+    If no .snakebids file is found, it raises an exception.
+
+    Parameters
+    ----------
+    outputdir : Path
+        Directory to check.
+
+    Returns
+    -------
+    Optional[Path]
+        None if output dir is nonexistant or empty, otherwise the path
+        of the .snakbids file
+
+    Raises
+    ------
+    RunError
+        Raised if outputdir contains contents but no .snakebids file
+
+    """
+    # Check if outputdir exits
+    if not outputdir.exists():
+        return None
+
+    # If it does exist, is it empty?
+    elif len([*outputdir.iterdir()]) == 0:
+        return None
+
+    # If it's not empty, is there a .snakebids file?
+    elif (outputdir / ".snakebids").exists():
+        return (outputdir / ".snakebids")
+    
+    # We have an occupied directory without a .snakebids file, so we have no idea
+    # what's there.
+    else:
+        raise RunError(
+            f"Output dir `{outputdir.resolve()}` exists, but `.snakebids` file "
+            "not found. Please specify either a new directory, or a ",
+            "directory where you've previously run this Snakebids app."
+        )
+
+
+def _check_for_results_folder(root: Path):
+    """Check folder for results folder
+    
+    Raises exception if it does exist, otherwise returns the name of the folder it
+    looked for.
+
+    Parameters
+    ----------
+    root : Path
+        Folder in which to search
+
+    Returns
+    -------
+    Path
+        Name of folder searched for.
+
+    Raises
+    ------
+    RunError
+        Raised if results folder found
+
+    """
+    results = root / "results"
+    if results.exists():
+        raise RunError(
+            "Cannot convert output format as a results folder or file already "
+            f"exists in your data directory ({results}). Please rename or remove "
+            "this item."
+        )
+    return results
+
+
+def get_time_hash():
+    """currently unused"""
+    import hashlib
+    import time
+
+    hash = hashlib.sha1()
+    hash.update(str(time.time()).encode('utf-8'))
+    return hash.hexdigest()[:8]
+
+
+def write_config_file(config_file: Path, data: dict, force_overwrite: bool = False):
+    if (config_file.exists()) and not force_overwrite:
+        raise RunError(
+            f"A config file named {config_file.name} already exists:\n"
+            f"\t{config_file}\n"
+            "Please move or rename either the existing or incoming config."
+        )
+    config_file.parent.mkdir(exist_ok=True)
+
+    # TODO: copy to a time-hashed file for provenance purposes? 
+    #       unused as of now.. 
+    time_hash = get_time_hash() 
+
+    
+    with open(config_file, "w") as f:
+        # write either as JSON or YAML
+        if config_file.suffix == '.json':
+            import json
+            json.dump(data, f, indent=4)
+            return
+
+        # if not json, then should be yaml or yml
+        from collections import OrderedDict
+        
+        # this is needed to make the output yaml clean
+        yaml.add_representer(
+            OrderedDict,
+            lambda dumper, data: dumper.represent_mapping(
+                'tag:yaml.org,2002:map',
+                data.items()
+            )
+        )
+
+        # Represent any PathLikes as str.
+        path2str = lambda dumper, data: dumper.represent_scalar(
+            'tag:yaml.org,2002:str',
+            str(data)
+        )
+        yaml.add_representer(PosixPath, path2str)
+        yaml.add_representer(WindowsPath, path2str)
+
+        yaml.dump(
+            data,
+            f, 
+            default_flow_style=False,
+            sort_keys=False
+        )

--- a/snakebids/output.py
+++ b/snakebids/output.py
@@ -444,7 +444,7 @@ def write_config_file(config_file: Path, data: dict, force_overwrite: bool = Fal
     if (config_file.exists()) and not force_overwrite:
         raise RunError(
             f"A config file named {config_file.name} already exists:\n"
-            f"\t{config_file}\n"
+            f"\t- {config_file.resolve()}\n"
             "Please move or rename either the existing or incoming config."
         )
     config_file.parent.mkdir(exist_ok=True)

--- a/snakebids/project_template/cookiecutter.json
+++ b/snakebids/project_template/cookiecutter.json
@@ -5,6 +5,6 @@
   "app_full_name": "My BIDS App",
   "app_name": "{{ cookiecutter.app_full_name.lower().replace(' ', '_').replace('-', '_') }}",
   "app_description": "My template snakebids app.",
-  "snakebids_version": "0.3.17",
+  "snakebids_version": "0.4.0-alpha.0",
   "_py": "py"
 }

--- a/snakebids/project_template/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/workflow/Snakefile
+++ b/snakebids/project_template/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/workflow/Snakefile
@@ -3,7 +3,7 @@
 import snakebids
 from snakebids import bids
 
-configfile: 'config/snakebids.yml'
+configfile: workflow.source_path('..config/snakebids.yml')
 
 #writes inputs_config.yml and updates config dict
 config.update(
@@ -29,14 +29,14 @@ wildcard_constraints:  **snakebids.get_wildcard_constraints(\
 
 rule all:
     input: 
-        expand( bids(root='results', datatype='func',suffix='bold.nii.gz', desc='smooth{fwhm}mm', **config['input_wildcards']['bold']), 
+        expand( bids(root=config['root'], datatype='func',suffix='bold.nii.gz', desc='smooth{fwhm}mm', **config['input_wildcards']['bold']), 
             fwhm = config['smoothing_fwhm'],**config['input_lists']['bold'])
 
 
 rule smooth:
     input: config['input_path']['bold']
     params: sigma = lambda wildcards: f'{float(wildcards.fwhm)/2.355:0.2f}'
-    output: bids(root='results', datatype='func',\
+    output: bids(root=config['root'], datatype='func',\
                   desc='smooth{fwhm}mm', suffix='bold.nii.gz',\
                   **config['input_wildcards']['bold'])
     container: config['singularity']['fsl']

--- a/snakebids/tests/test_app.py
+++ b/snakebids/tests/test_app.py
@@ -64,7 +64,7 @@ class TestArgTypeAnnotation:
 
     @pytest.fixture
     def parser(self, app):
-        return app._SnakeBidsApp__create_parser()
+        return app._create_parser()
 
     def test_snakebids_app_is_properly_mocked(self, app):
         assert isinstance(app, SnakeBidsApp)
@@ -90,11 +90,11 @@ class TestArgTypeAnnotation:
             "type": "UnheardClass"
         }
         with pytest.raises(TypeError):
-            app._SnakeBidsApp__create_parser()
+            app._create_parser()
 
     def test_resolves_paths(self, app: SnakeBidsApp, mocker: MockerFixture):
         mocker.patch.object(sys, 'argv', self.mock_all_args)
-        app.parser = app._SnakeBidsApp__create_parser()
-        app._SnakeBidsApp__parse_args()
+        app.parser = app._create_parser()
+        app._parse_args()
         assert app.config["bids_dir"] == Path.cwd() / "path/to/input"
         assert app.config["derivatives"][0] == Path.cwd() / "path/to/nowhere" 

--- a/snakebids/tests/test_app.py
+++ b/snakebids/tests/test_app.py
@@ -128,6 +128,7 @@ class TestRunSnakemake:
         app.force = False
         expected_config = copy.deepcopy(app.config)
         expected_config["output_dir"] = "/tmp/output/results"
+        expected_config["root"] = "results"
 
         io_mocks["prepare_output"].return_value = Path("/tmp/output/results")
 
@@ -166,6 +167,7 @@ class TestRunSnakemake:
         app.snakemake_dir = Path("app")
         app.force = False
         expected_config = copy.deepcopy(app.config)
+        expected_config["root"] = ""
 
         io_mocks["prepare_output"].return_value = Path("/tmp/output")
 
@@ -191,7 +193,7 @@ class TestRunSnakemake:
             "--snakefile",
             app.snakefile,
             "--directory",
-            "app",
+            "/tmp/output",
             "--configfile",
             "/tmp/output/code/config.yaml"
         ])
@@ -207,6 +209,7 @@ class TestRunSnakemake:
         app.force = False
         expected_config = copy.deepcopy(app.config)
         expected_config["output_dir"] = "app/results"
+        expected_config["root"] = "results"
 
         io_mocks["prepare_output"].return_value = Path("app/results")
 

--- a/snakebids/tests/test_app.py
+++ b/snakebids/tests/test_app.py
@@ -185,7 +185,7 @@ class TestRunSnakemake:
         io_mocks["write_config"].assert_called_once_with(
             Path("/tmp/output/code/config.yaml"),
             expected_config,
-            False
+            True
         )
         io_mocks["snakemake"].assert_called_once_with([
             "--snakefile",

--- a/snakebids/tests/test_app.py
+++ b/snakebids/tests/test_app.py
@@ -1,6 +1,8 @@
 # Core
 import sys, copy
 from pathlib import Path
+from typing import Dict
+from unittest.mock import MagicMock
 
 # Testing 
 import pytest
@@ -10,17 +12,29 @@ from argparse import ArgumentParser
 from os import PathLike
 from configargparse import Namespace
 
+import snakemake
 # Fixtures
 from pytest_mock.plugin import MockerFixture
 
 # Local
+from .. import app as sn_app
 from ..app import SnakeBidsApp, resolve_path
+
 from .mock.config import config
+
 
 def init_snakebids_app(self):
     self.configfile_path="mock/config.yaml"
     self.snakefile = "mock/Snakefile"
+    self.retrofit = False
     self.config = copy.deepcopy(config)
+    self.config["analysis_level"] = "participant"
+    self.config["snakemake_args"] = []
+
+@pytest.fixture
+def app(mocker: MockerFixture):
+    mocker.patch.object(SnakeBidsApp, '__init__', init_snakebids_app)
+    return SnakeBidsApp()
 
 class TestResolvePath:
     @pytest.fixture
@@ -58,11 +72,6 @@ class TestArgTypeAnnotation:
     mock_all_args = mock_basic_args + mock_args_special 
 
     @pytest.fixture
-    def app(self, mocker: MockerFixture):
-        mocker.patch.object(SnakeBidsApp, '__init__', init_snakebids_app)
-        return SnakeBidsApp()
-
-    @pytest.fixture
     def parser(self, app):
         return app._create_parser()
 
@@ -98,3 +107,135 @@ class TestArgTypeAnnotation:
         app._parse_args()
         assert app.config["bids_dir"] == Path.cwd() / "path/to/input"
         assert app.config["derivatives"][0] == Path.cwd() / "path/to/nowhere" 
+
+
+class TestRunSnakemake:
+    @pytest.fixture
+    def io_mocks(self, mocker: MockerFixture):
+        return {
+            "write_output_mode": mocker.patch.object(sn_app, 'write_output_mode'),
+            "prepare_output": mocker.patch.object(sn_app, 'prepare_output'),
+            "write_config": mocker.patch.object(sn_app, 'write_config_file'),
+            "snakemake": mocker.patch.object(snakemake, 'main'),
+        }
+
+    def test_runs_in_workflow_mode(
+        self, io_mocks: Dict[str, MagicMock], app: SnakeBidsApp
+    ):
+        app.workflow_mode = True
+        app.outputdir = Path("/tmp/output")
+        app.snakemake_dir = Path("app")
+        app.force = False
+        expected_config = copy.deepcopy(app.config)
+        expected_config["output_dir"] = "/tmp/output/results"
+
+        io_mocks["prepare_output"].return_value = Path("/tmp/output/results")
+
+        try:
+            app.run_snakemake()
+        except SystemExit as e:
+            print("System exited prematurely")
+            print(e)
+        
+        io_mocks["write_output_mode"].assert_not_called()
+        io_mocks["prepare_output"].assert_called_once_with(
+            Path("app"),
+            Path("/tmp/output"),
+            "workflow",
+            False
+        )
+        io_mocks["write_config"].assert_called_once_with(
+            Path("/tmp/output/mock/config.yaml"),
+            expected_config,
+            False
+        )
+        io_mocks["snakemake"].assert_called_once_with([
+            "--snakefile",
+            app.snakefile,
+            "--directory",
+            "/tmp/output",
+            "--configfile",
+            "/tmp/output/mock/config.yaml"
+        ])
+
+    def test_runs_in_bidsapp_mode(
+        self, io_mocks: Dict[str, MagicMock], app: SnakeBidsApp
+    ):
+        app.workflow_mode = False
+        app.outputdir = Path("/tmp/output")
+        app.snakemake_dir = Path("app")
+        app.force = False
+        expected_config = copy.deepcopy(app.config)
+
+        io_mocks["prepare_output"].return_value = Path("/tmp/output")
+
+        try:
+            app.run_snakemake()
+        except SystemExit as e:
+            print("System exited prematurely")
+            print(e)
+        
+        io_mocks["write_output_mode"].assert_not_called()
+        io_mocks["prepare_output"].assert_called_once_with(
+            Path("app"),
+            Path("/tmp/output"),
+            "bidsapp",
+            False
+        )
+        io_mocks["write_config"].assert_called_once_with(
+            Path("/tmp/output/code/config.yaml"),
+            expected_config,
+            False
+        )
+        io_mocks["snakemake"].assert_called_once_with([
+            "--snakefile",
+            app.snakefile,
+            "--directory",
+            "app",
+            "--configfile",
+            "/tmp/output/code/config.yaml"
+        ])
+
+    def test_runs_in_workflow_mode_when_output_same_as_snakebids_app(
+        self,
+        io_mocks: Dict[str, MagicMock],
+        app: SnakeBidsApp
+    ):
+        app.workflow_mode = False
+        app.outputdir = Path("app")
+        app.snakemake_dir = Path("app")
+        app.force = False
+        expected_config = copy.deepcopy(app.config)
+        expected_config["output_dir"] = "app/results"
+
+        io_mocks["prepare_output"].return_value = Path("app/results")
+
+        try:
+            app.run_snakemake()
+        except SystemExit as e:
+            print("System exited prematurely")
+            print(e)
+        
+        io_mocks["write_output_mode"].assert_called_once_with(
+            Path("app/.snakebids"),
+            "workflow"
+        )
+        io_mocks["prepare_output"].assert_called_once_with(
+            Path("app"),
+            Path("app"),
+            "workflow",
+            False
+        )
+        io_mocks["write_config"].assert_called_once_with(
+            Path("app/mock/config.yaml"),
+            expected_config,
+            True
+        )
+        io_mocks["snakemake"].assert_called_once_with([
+            "--snakefile",
+            app.snakefile,
+            "--directory",
+            "app",
+            "--configfile",
+            str(Path("app/mock/config.yaml").resolve())
+        ])

--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -3,7 +3,7 @@ import os
 from bids import BIDSLayout
 import pytest
 
-from .. import generate_inputs, __get_lists_from_bids
+from .. import generate_inputs, _get_lists_from_bids
 
 
 def test_t1w():
@@ -178,7 +178,7 @@ def test_get_lists_from_bids():
         elif idx == 2:
             pybids_inputs["t2"]["custom_path"] = wildcard_path_t2
 
-        config = __get_lists_from_bids(layout, pybids_inputs)
+        config = _get_lists_from_bids(layout, pybids_inputs)
         assert config["input_path"] == {
             "t1": wildcard_path_t1,
             "t2": wildcard_path_t2,

--- a/snakebids/tests/test_output.py
+++ b/snakebids/tests/test_output.py
@@ -1,0 +1,318 @@
+import itertools as it
+import json
+from pathlib import Path
+import shutil
+from typing import Callable
+
+import pytest
+from pytest_mock.plugin import MockerFixture
+
+from snakebids.exceptions import RunError
+import snakebids.output as output
+
+dirlen: Callable[[Path], int] = lambda f: len([*f.iterdir()])
+
+@pytest.fixture
+def fake_snakemake(tmp_path: Path):
+    app1 = tmp_path / "app1"
+    app1.mkdir()
+    (app1 / "random_file").touch()
+    (app1 / ".snakebids").touch()
+    (app1 / "config").mkdir()
+    (app1 / "config" / "config.yaml").touch()
+
+    (app1 / "results" / "app1").mkdir(parents=True)
+    (app1 / "results" / "app1" / "result1.data").touch()
+    (app1 / "results" / "app1" / "link").symlink_to(
+        app1 / "results" / "app1" / "rule1.smk"
+    )
+
+    (app1 / "workflow" / "rules").mkdir(parents=True)
+    (app1 / "workflow" / "Snakefile").touch()
+    (app1 / "workflow" / "rules" / "rule1.smk").touch()
+    (app1 / "workflow" / "rules" / "link").symlink_to(
+        app1 / "workflow" / "rules" / "rule1.smk"
+    )
+
+    output = tmp_path/"output"
+    output.mkdir()
+    (output/"random_file").touch()
+    (output/".snakebids").touch()
+    (output/"app1").mkdir(parents=True)
+    (output/"app1"/"special_results.data").touch()
+
+    old_style = tmp_path/"old-style"
+    old_style.mkdir()
+    (old_style/"config").mkdir()
+    (old_style/"config"/"config.yaml").mkdir()
+    (old_style/"app1").mkdir(parents=True)
+    (old_style/"app1"/"special_results.data").touch()
+
+    randomdir = tmp_path/"randomdir"
+    randomdir.mkdir()
+    (randomdir/"somefile").touch()
+
+    return tmp_path
+
+class TestCheckForResultsFolder:
+    def test_raises_error_if_folder_exists(self, tmp_path: Path):
+        (tmp_path / "results").mkdir()
+        with pytest.raises(RunError):
+            output._check_for_results_folder(tmp_path)
+    
+    def test_raises_error_if_file_exists(self, tmp_path: Path):
+        (tmp_path / "results").touch()
+        with pytest.raises(RunError):
+            output._check_for_results_folder(tmp_path)
+    
+    def test_returns_results_path_if_doesnt_exist(self, tmp_path: Path):
+        path = output._check_for_results_folder(tmp_path)
+        assert path == tmp_path / "results"
+
+
+class TestGetSnakebidsFile:
+    def test_raises_error_if_contents_but_no_snakebids_file(self, tmp_path: Path):
+        (tmp_path / "some_file").touch()
+        with pytest.raises(RunError):
+            output._get_snakebids_file(tmp_path)
+
+    def test_returns_path_of_snakebids_file_if_found(self, tmp_path: Path):
+        (tmp_path / "some_file").touch()
+        (tmp_path / ".snakebids").touch()
+        path = output._get_snakebids_file(tmp_path)
+        assert path == tmp_path / ".snakebids"
+
+    def test_returns_none_if_directory_empty(self, tmp_path: Path):
+        assert output._get_snakebids_file(tmp_path) == None
+
+    def test_returns_none_if_directory_nonexistant(self, tmp_path: Path):
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        assert output._get_snakebids_file(empty_dir) == None
+
+
+def test_copy_snakemake_app(fake_snakemake: Path):
+    # Major uncovered cases:
+    #   - symlinks pointing outside the copied body
+    app2 = fake_snakemake/"app2"
+    out = output._copy_snakemake_app(fake_snakemake/"app1", app2)
+
+    assert out == fake_snakemake/"app2"/"results"
+    assert dirlen(app2 / "results") == 0
+    assert dirlen(app2 / "config") == 0
+    assert (app2 / "workflow/Snakefile").exists()
+    assert (app2 / "workflow/rules/rule1.smk").exists()
+    assert (
+        (app2 / "workflow/rules/link").resolve() == app2/"workflow/rules/rule1.smk"
+    )
+
+class TestConvertOutput:
+    @pytest.mark.parametrize(
+        "mode,force", it.product(("workflow", "bidsapp"), (True, False))
+    )
+    def test_does_nothing_when_start_and_end_are_the_same(
+        self, tmp_path: Path, mode: output.Mode, force: bool
+    ):
+        if mode == "bidsapp":
+            assert (
+                output._convert_output(
+                    mode, mode, tmp_path, tmp_path, force
+                ) is tmp_path
+            )
+        else:
+            assert (
+                output._convert_output(
+                    mode, mode, tmp_path, tmp_path, force
+                ) == tmp_path/"results"
+            )
+
+    def test_workflow_conversion_fails_when_results_present(self, fake_snakemake: Path):
+        with pytest.raises(RunError):
+            output._convert_output(
+                "bidsapp",
+                "workflow",
+                fake_snakemake/"app1",
+                fake_snakemake/"app1",
+                True
+            )
+
+    def test_conversion_to_workflow(self, fake_snakemake: Path):
+        out = output._convert_output(
+            "bidsapp",
+            "workflow",
+            fake_snakemake/"app1",
+            fake_snakemake/"output",
+            True
+        )
+        assert out == fake_snakemake/"output"/"results"
+        assert dirlen(fake_snakemake/"output") == 5
+        assert dirlen(out/"app1") == 1
+        assert (out/"app1"/"special_results.data").exists()
+
+
+    def test_raise_exception_when_convert_to_bidsapp_without_force(
+        self,
+        fake_snakemake: Path
+    ):
+        output._convert_output(
+            "bidsapp",
+            "workflow",
+            fake_snakemake/"app1",
+            fake_snakemake/"output",
+            True)
+
+        with pytest.raises(RunError):
+            output._convert_output(
+                "workflow",
+                "bidsapp",
+                fake_snakemake/"app1",
+                fake_snakemake/"output",
+                False
+            )
+
+    def test_converts_to_bidsapp_when_forced(self, fake_snakemake: Path):
+        output._convert_output(
+            "bidsapp",
+            "workflow",
+            fake_snakemake/"app1",
+            fake_snakemake/"output",
+            True)
+
+        out = output._convert_output(
+            "workflow",
+            "bidsapp",
+            fake_snakemake/"app1",
+            fake_snakemake/"output",
+            True
+        )
+
+        assert out == fake_snakemake/"output"
+        assert dirlen(out) == 3
+
+class TestPrepareOutput:
+    def test_creates_new_empty_workflow_app(self, fake_snakemake: Path):
+        out = output.prepare_output(
+            fake_snakemake/"app1",
+            fake_snakemake/"new-output",
+            "workflow",
+            False
+        )
+
+        assert out == fake_snakemake/"new-output"/"results"
+        assert dirlen(fake_snakemake/"new-output") == 5
+        assert out.exists()
+        assert dirlen(out) == 0
+        with (fake_snakemake/"new-output"/".snakebids").open() as f:
+            assert json.load(f)["mode"] == "workflow"
+
+
+    def test_creates_new_empty_bidsapp(self, fake_snakemake: Path):
+        out = output.prepare_output(
+            fake_snakemake/"app1",
+            fake_snakemake/"new-output",
+            "bidsapp",
+            False
+        )
+
+        assert out == fake_snakemake/"new-output"
+        assert out.exists()
+        assert dirlen(out) == 1
+        with (out/".snakebids").open() as f:
+            assert json.load(f)["mode"] == "bidsapp"
+
+    def test_converts_bidsapp_to_workflow(self, fake_snakemake: Path):
+        with (fake_snakemake/"output"/".snakebids").open('w') as f:
+            json.dump({
+                "mode": "bidsapp"
+            }, f)
+        out = output.prepare_output(
+            fake_snakemake/"app1",
+            fake_snakemake/"output",
+            "workflow",
+            False
+        )
+
+        assert out == fake_snakemake/"output"/"results"
+        assert dirlen(fake_snakemake/"output") == 5
+        assert out.exists()
+        assert dirlen(out) == 2
+        with (fake_snakemake/"output"/".snakebids").open() as f:
+            assert json.load(f)["mode"] == "workflow"
+
+    def test_converts_workflow_app_to_bidsapp(self, fake_snakemake: Path):
+        with (fake_snakemake/"output"/".snakebids").open('w') as f:
+            json.dump({
+                "mode": "bidsapp"
+            }, f)
+        output.prepare_output(
+            fake_snakemake/"app1",
+            fake_snakemake/"output",
+            "workflow",
+            False
+        )
+
+        out = output.prepare_output(
+            fake_snakemake/"app1",
+            fake_snakemake/"output",
+            "bidsapp",
+            True
+        )
+
+        assert out == fake_snakemake/"output"
+        assert out.exists()
+        assert dirlen(out) == 3
+        with (out/".snakebids").open() as f:
+            assert json.load(f)["mode"] == "bidsapp"
+
+
+    def test_fails_when_directory_has_contents(self, fake_snakemake: Path):
+        with pytest.raises(RunError):
+            output.prepare_output(
+                fake_snakemake/"app1",
+                fake_snakemake/"randomdir",
+                "workflow",
+                False
+            )
+
+class TestRetrofitOutput:
+    def test_successfully_retrofits(self, fake_snakemake: Path, mocker: MockerFixture):
+        o = fake_snakemake/"old-style"
+        mocker.patch('builtins.input', return_value="yes")
+        out = output.retrofit_output(o, [o/"config/config.yaml"])
+        assert out == True
+        assert not (o/"config").exists()
+        assert dirlen(o/"app1") == 1
+        with (o/".snakebids").open() as f:
+            assert json.load(f)["mode"] == "bidsapp"
+
+    def test_fails_when_user_input_not_yes(
+        self, fake_snakemake: Path, mocker: MockerFixture
+    ):
+        o = fake_snakemake/"old-style"
+        mocker.patch('builtins.input', return_value="")
+        out = output.retrofit_output(o, [o/"config/config.yaml"])
+        assert out == False
+        assert (o/"config").exists()
+    
+    def test_fails_when_snakebids_file_exists(
+        self, fake_snakemake: Path, mocker: MockerFixture
+    ):
+        o = fake_snakemake/"old-style"
+        (o/".snakebids").touch()
+        with pytest.raises(RunError):
+            output.retrofit_output(o, [o/"config/config.yaml"])
+
+    def test_fails_if_no_config_files_provided(
+        self, fake_snakemake: Path, mocker: MockerFixture
+    ):
+        o = fake_snakemake/"old-style"
+        with pytest.raises(RunError):
+            output.retrofit_output(o, [])
+
+    def test_fails_if_unknown_files_in_config_folder(
+        self, fake_snakemake: Path, mocker: MockerFixture
+    ):
+        o = fake_snakemake/"old-style"
+        (o/"config"/"random").touch()
+        with pytest.raises(RunError):
+            output.retrofit_output(o, [o/"config/config.yaml"])

--- a/snakebids/tests/test_output.py
+++ b/snakebids/tests/test_output.py
@@ -24,15 +24,12 @@ def fake_snakemake(tmp_path: Path):
     (app1 / "results" / "app1").mkdir(parents=True)
     (app1 / "results" / "app1" / "result1.data").touch()
     (app1 / "results" / "app1" / "link").symlink_to(
-        app1 / "results" / "app1" / "rule1.smk"
+        app1 / "workflow" / "rules" / "rule1.smk"
     )
 
     (app1 / "workflow" / "rules").mkdir(parents=True)
     (app1 / "workflow" / "Snakefile").touch()
     (app1 / "workflow" / "rules" / "rule1.smk").touch()
-    (app1 / "workflow" / "rules" / "link").symlink_to(
-        app1 / "workflow" / "rules" / "rule1.smk"
-    )
 
     output = tmp_path/"output"
     output.mkdir()
@@ -102,9 +99,7 @@ def test_copy_snakemake_app(fake_snakemake: Path):
     assert dirlen(app2 / "config") == 0
     assert (app2 / "workflow/Snakefile").exists()
     assert (app2 / "workflow/rules/rule1.smk").exists()
-    assert (
-        (app2 / "workflow/rules/link").resolve() == app2/"workflow/rules/rule1.smk"
-    )
+    assert not (app2/"results/app1/link").exists()
 
 class TestConvertOutput:
     @pytest.mark.parametrize(

--- a/snakebids/tests/test_output.py
+++ b/snakebids/tests/test_output.py
@@ -31,6 +31,8 @@ def fake_snakemake(tmp_path: Path):
     (app1 / "workflow" / "Snakefile").touch()
     (app1 / "workflow" / "rules" / "rule1.smk").touch()
 
+    (app1/".snakemake").mkdir()
+
     output = tmp_path/"output"
     output.mkdir()
     (output/"random_file").touch()
@@ -95,6 +97,7 @@ def test_copy_snakemake_app(fake_snakemake: Path):
     out = output._copy_snakemake_app(fake_snakemake/"app1", app2)
 
     assert out == fake_snakemake/"app2"/"results"
+    assert not (out/".snakemake").exists()
     assert dirlen(app2 / "results") == 0
     assert dirlen(app2 / "config") == 0
     assert (app2 / "workflow/Snakefile").exists()
@@ -228,6 +231,7 @@ class TestPrepareOutput:
         )
 
         assert out == fake_snakemake/"output"/"results"
+        assert not (out/".snakemake").exists()
         assert dirlen(fake_snakemake/"output") == 5
         assert out.exists()
         assert dirlen(out) == 2
@@ -246,6 +250,9 @@ class TestPrepareOutput:
             False
         )
 
+        assert not (fake_snakemake/"output"/".snakemake").exists()
+        (fake_snakemake/"output"/".snakemake").touch()
+
         out = output.prepare_output(
             fake_snakemake/"app1",
             fake_snakemake/"output",
@@ -254,8 +261,9 @@ class TestPrepareOutput:
         )
 
         assert out == fake_snakemake/"output"
+        assert (fake_snakemake/"output"/".snakemake").exists()
         assert out.exists()
-        assert dirlen(out) == 3
+        assert dirlen(out) == 4
         with (out/".snakebids").open() as f:
             assert json.load(f)["mode"] == "bidsapp"
 
@@ -311,3 +319,4 @@ class TestRetrofitOutput:
         (o/"config"/"random").touch()
         with pytest.raises(RunError):
             output.retrofit_output(o, [o/"config/config.yaml"])
+        


### PR DESCRIPTION
## TODOs
- [x] Update sphinx documentation
- [x] Improve exception handling (e.g. by catching `RunError` and printing a nicely formatted message without the trace)
- [x] Finalize handling of the `.snakemake` folder.
- [x] Prevent deletion of `.snakemake` folder when converting from workflow to bidsapp mode
- [x] Bump version to 0.4.0a1 and disable bumpversion for now

## Overview
With this PR, snakebids will, by default, produce output in bidsapp mode, meaning snakemake results will be placed directly in the output folder. The user, via command line flag `--workflow-mode` or `-w`, can change the output to "workflow mode" which will cause the entire snakebids app to be copied to the output dir. Snakemake results will be put into the `output/results` folder.

## Problem
Currently, snakebids produces output in roughly a bidsapp fashion, but still produces a `config/config.yml` file in the output directory. There is no convenient way to use the `run.py` function in a manner analogous to snakemake, that is, to run a pipeline progressively and iteratively, collecting the outputs in the results folder. At the same time, it doesn't particularly conform to bidsapp specs either, with the production of an extra config folder in the output.

## Details
### bidsapp and workflow modes
bidsapp mode is intended to emulate a typical bids app. The application produces just the ouptut, placed in the folder chosen by the user. Because it's the most transparent mode, and doesn't change the users output path or add extra files, it's set to be the default. The user must opt into workflow mode using a CLI flag. To keep a record of runtime parameters, the config file is saved into the `output/code` folder, in accordance with the bids spec. Successive runs of the snakebids app will overwrite the config file saved into the code folder unless the name of the config file is changed by the user.

Workflow mode is intended for modification and development of the pipeline. By setting the CLI flag, the snakebids app (parent) will reproduce itself (a child) in the output directory specified by the user, putting the snakemake results in the `output/results` folder. This newly created copy of the snakebids app will be set as the working directory for snakemake. This mode is not intended to be run multiple times in succession. Rather, Snakemake should be run directly in the child app. If the user runs the parent app in workflow mode a second time, no files will be copied over except for the `config.yaml` file being used for the run. However, if the parent finds a `config.yaml` of the same name already in the child, it will throw an error.

Both in bidsapp and in workflow modes, the appropriate directory for results will be made available to the Snakefile in the variable: `config["bids_dir"]`.

### .snakebids file
To track the mode of output directories, snakebids generates a `.snakebids` file at the top level of each output. This is a simple json file that currently has just one field: mode. In the future, this file should be expanded to include more metadata and tracking.

Using the `.snakebids` file, snakebids can convert between bidsapp and workflow mode, and vice versa. Note that in the conversion from workflow to bidsapp mode, all of the workflow files, metadata, and everything that's not in the results folder in the child app will be deleted. As such, snakebids will refuse to perform such a conversion unless provided with the `--force-conversion` flag.

As extra precautions, snakebids will refuse to make output in a directory already containing items. It will not convert between bidsapp and workflow modes (or vice versa) if the snakemake results itself contains a results folder. 

### Running in itself
If the parent app itself is set as the output directory, Snakebids will automatically switch to workflow mode, alerting the user of this fact if they did not specify such. Results will, as usual, be put in the results folder.

### Retrofit function
To facilitate the conversion of legacy outputs to the new format, snakebids provides a --retrofit flag.
Running this with an appropriate output, Snakemake will delete any config files found in the output and generate a new `.snakebids` file. The user will be prompted with the list of files to be deleted for confirmation. This will not work if unrecognized files (anything not a config file in the list in app.py) are found in the `output/config` folder.

Retrofit puts the output in bidsapp mode, but the user can switch to workflow mode immediately just by adding the `-W` flag.

## Limitations
- Because of the current simplicity of the `.snakebids` file, Snakebids cannot currently distinguish between outputs generated by the current app or different apps. This can be improved in future editions.

## Omnibus Issues
These technically should have got their own PRs, but got merged in along the way:
- Private functions were defined using double underscores: `__method()`. This has a special meaning in Python and causes mangling of the method name, making it difficult to test ([see here](https://stackoverflow.com/questions/1301346/what-is-the-meaning-of-single-and-double-underscore-before-an-object-name)). These were thus switched to the more canonical single underscore `_method()`. 
- To make way for a new exception and prevent confusion, all exceptions were moved to their own module
- The import syntax for `pybids.config` was changed to satisfy my IDE linter.  `pybids.config` is not directly importable, technically (although it seemed to work anyhow?). At any rate, the current syntax is cleaner and gives me no squiggly lines.
- Snakemake is now run directly, rather than using a subprocess. This allows colors to still be displayed.
