### PR TITLE
Update documentation for output modes

### DIFF
--- a/docs/running_snakebids/overview.rst
+++ b/docs/running_snakebids/overview.rst
@@ -11,3 +11,96 @@ Note that if any rules in the snakebids workflow use Singularity containers, spe
 
 1. Inputs are copied into a working subdirectory of the output directory before any processing that requires a Singularity container is performed, or:
 2. The ``SINGULARITY_BINDPATH`` environment variable binds the location of the input dataset.
+
+Workflow mode
+=============
+
+Snakebids apps use a BIDS app CLI, giving great flexibility when switching datasets. However, when developing a Snakebids app or when running the app repeatedly on the same dataset, it can be more convenient to directly call the Snakemake CLI. Snakebids facilitates this using workflow mode.
+
+Workflow mode activates when the Snakebids app itself is used as the output folder. Snakebids will save your config file in the config folder and put any outputs in the results folder. After the first Snakebids call, the Snakemake CLI can be called directly using the generated config file. 
+
+As an example, suppose we have a BIDS formatted dataset::
+
+    dataset
+    ├── code
+    ├── dataset_description.json
+    ├── derivatives
+    ├── sub-001
+    ├── sub-002
+    ├── sub-003
+    ├── sub-004
+    ├── sub-005
+    ├── sub-006
+    ├── sub-007
+    ├── sub-008
+    └── sub-009
+
+We'd like to develop a new processing pipeline called SuperCorrect. We'll start by making a new directory in ``derivatives`` using the Snakemake CookieCutter template::
+
+    dataset
+    ├── code
+    ├── dataset_description.json
+    ├── derivatives
+    │   └── super_correct
+    │       ├── config
+    │       │   └── snakebids.yml
+    │       ├── pipeline_description.json
+    │       ├── run.py
+    │       └── workflow
+    │           └── Snakefile
+    ├── sub-001
+    ├── sub-002
+    ├── sub-003
+    ├── sub-004
+    ├── sub-005
+    ├── sub-006
+    ├── sub-007
+    ├── sub-008
+    └── sub-009
+
+``cd`` to ``super_correct``::
+
+    super_correct
+    ├── config
+    │   └── snakebids.yml
+    ├── pipeline_description.json
+    ├── run.py
+    └── workflow
+        └── Snakefile
+
+We then develop our pipeline, writing our ``Snakefile``, rules, etc. When we're ready to start testing, we start by calling our ``run.py`` function::
+
+    run.py ../../ . participant [snakemake args]
+
+We'll see a message telling us the app is running in snakemake mode and, if our workflow doesn't have any bugs, the app will run! ``config/snakebids.yml`` will be updated to include all the information we passed into the CLI. Output files will be in the ``results`` folder::
+
+    super_correct
+    ├── config
+    │   └── snakebids.yml
+    ├── pipeline_description.json
+    ├── results
+    │   └── super_correct
+    │       ├── dataset_description.json
+    │       ├── sub-001
+    │       ├── sub-002
+    │       ├── sub-003
+    │       ├── sub-004
+    │       ├── sub-005
+    │       ├── sub-006
+    │       ├── sub-007
+    │       ├── sub-008
+    │       └── sub-009
+    ├── run.py
+    └── workflow
+        └── Snakefile
+
+
+From now on, instead of calling ``run.py``, we can just the Snakemake CLI directly. It will use the same inputs and outputs saved into our config by Snakebids::
+
+    snakemake [args]
+
+You can still use the Snakebids CLI on other datasets. However, if you plan on modifying any files, including config, to make the Snakebids app suitable for the new dataset, it's recommended to use git to clone the app into the ``derivatives`` folder of the new dataset. Alternatively, you can call ``run.py`` with the ``--workflow-mode`` flag::
+
+    run.py /path/to/newdata /path/to/newdata/derivatives/super_correct participant --workflow-mode [snakemake args]
+
+This will make a copy of the Snakebids app at the new output directory, excluding the ``results`` folder and some configuration folders/files (``.snakemake/``, ``.snakebids``). It will, again, make a new config file, and put new results in the ``output/results`` folder.


### PR DESCRIPTION
Here's the documentation for the output modes. It right now takes Bidsapp mode for granted, and introduces workflow mode as a way of directly calling the Snakemake CLI. It also teaches users to directly create or clone the app to the directory they want their results to go, and only mentions the `-W` flag at the end.

Need to make sure the file tree structures render correctly on Readthedocs. Does anyone know how to test that?

Will parts of the documentation (especially the tutorial) need to be updated to reflect new assumptions made in Snakebids app development (e.g. what kind of output to expect in Bidsapp mode)?