### PR TITLE
Match path of config in bidsapp mode to parent

### DIFF
--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -486,7 +486,7 @@ class SnakeBidsApp:
         else:
             force_config_overwrite = True
             self.config["root"] = ""
-            new_config_file = self.outputdir / "code" / Path(self.configfile_path).name
+            new_config_file = self.outputdir / self.configfile_path
 
         cwd = self.outputdir
 

--- a/snakebids/tests/test_app.py
+++ b/snakebids/tests/test_app.py
@@ -180,7 +180,7 @@ class TestRunSnakemake:
             Path("app"), Path("/tmp/output"), "bidsapp", False
         )
         io_mocks["write_config"].assert_called_once_with(
-            Path("/tmp/output/code/config.yaml"), expected_config, True
+            Path("/tmp/output/mock/config.yaml"), expected_config, True
         )
         io_mocks["snakemake"].assert_called_once_with(
             [
@@ -189,7 +189,7 @@ class TestRunSnakemake:
                 "--directory",
                 "/tmp/output",
                 "--configfile",
-                "/tmp/output/code/config.yaml",
+                "/tmp/output/mock/config.yaml",
             ]
         )
 


### PR DESCRIPTION
This is a quick one addressing #66. The commit msg explains it well:

The config file in bidsapp mode was stored in the `code` directory in the output folder. This introduced a breaking change, as `Snakefiles` would need to refer to the config file via `workflow.source_path()`.  This adjusts the path to match that of the parent app: `parent/config/snakebids.yml` -> `output/config/snakebids.yml`

This way, 0.4.0 will not be breaking.

See #66
