### PR TITLE
Add test support for python 3.10.

### DIFF
--- a/.github/workflows/test_deploy.yml
+++ b/.github/workflows/test_deploy.yml
@@ -69,7 +69,7 @@ jobs:
     needs: [ 'quality'  ]
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ include = ["snakebids/project_template"]
 exclude = ["snakebids/tests/**"]
 
 [tool.poetry.dependencies]
-python = ">=3.7,<3.10"
+python = ">=3.7,<3.11"
 pybids = "^0.13.2"
 snakemake = ">=5.28.0"
 PyYAML = "^5.3.1"


### PR DESCRIPTION
Adds Python 3.10.x as a test condition and ups the python version restriction in the pyproject