### PR TITLE
Add --dash-syntax as alias to all CLI args

### DIFF
--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -257,6 +257,7 @@ class SnakeBidsApp:
 
         parser.add_argument(
             "--workflow-mode",
+            "--workflow_mode",
             "-W",
             action="store_true",
             help=(
@@ -270,6 +271,7 @@ class SnakeBidsApp:
         # We use -x as the alias because both -f and -F are taken by snakemake
         parser.add_argument(
             "--force-conversion",
+            "--force_conversion",
             "-x",
             action="store_true",
             help=(
@@ -290,6 +292,7 @@ class SnakeBidsApp:
 
         # add option for printing out snakemake usage
         parser.add_argument(
+            "--help-snakemake",
             "--help_snakemake",
             nargs=0,
             action=SnakemakeHelpAction,
@@ -328,7 +331,7 @@ class SnakeBidsApp:
         )
 
         for input_type in self.config["pybids_inputs"].keys():
-            argname = f"--filter_{input_type}"
+            argnames = (f"--filter_{input_type}", f"--filter-{input_type}")
             arglist_default = [
                 f"{key}={value}"
                 for (key, value) in self.config["pybids_inputs"][input_type][
@@ -338,7 +341,7 @@ class SnakeBidsApp:
             arglist_default_string = " ".join(arglist_default)
 
             filter_opts.add_argument(
-                argname,
+                *argnames,
                 nargs="+",
                 action=KeyValue,
                 help=f"(default: {arglist_default_string})",
@@ -353,14 +356,14 @@ class SnakeBidsApp:
         )
 
         for input_type in self.config["pybids_inputs"].keys():
-            argname = f"--wildcards_{input_type}"
+            argnames = (f"--wildcards-{input_type}", f"--wildcards_{input_type}")
             arglist_default = [
                 f"{wc}" for wc in self.config["pybids_inputs"][input_type]["wildcards"]
             ]
             arglist_default_string = " ".join(arglist_default)
 
             wildcards_opts.add_argument(
-                argname,
+                *argnames,
                 nargs="+",
                 help=f"(default: {arglist_default_string})",
             )
@@ -376,8 +379,8 @@ class SnakeBidsApp:
 
         # create path override parser
         for input_type in self.config["pybids_inputs"].keys():
-            argname = f"--path_{input_type}"
-            override_opts.add_argument(argname, default=None)
+            argnames = (f"--path-{input_type}", f"--path_{input_type}")
+            override_opts.add_argument(*argnames, default=None)
 
         return parser
 

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import os
 import pathlib
+import re
 import subprocess
 import sys
 
@@ -233,6 +234,7 @@ class SnakeBidsApp:
         if not skip_parse_args:
             self._parse_args()
 
+    # pylint: disable=too-many-locals
     def _create_parser(self, include_snakemake=False):
         """Create a parser with snakemake parser as parent solely for
         displaying help and checking conflicts, but then for actual parsing
@@ -320,7 +322,16 @@ class SnakeBidsApp:
                         + f"as a type for {name}"
                     ) from err
 
-            app_group.add_argument(name, **parse_args)
+            if re.match(r"^--", name):
+                name_part = re.match(r"^--(.+)$", name).group(1)
+                names = (
+                    name,
+                    re.sub(r"\_", "-", name),
+                    f"--{re.sub(r'-', '_', name_part)}",
+                )
+            else:
+                names = (name,)
+            app_group.add_argument(*names, **parse_args)
 
         # general parser for
         # --filter_{input_type} {key1}={value1} {key2}={value2}...

--- a/snakebids/tests/mock/config.py
+++ b/snakebids/tests/mock/config.py
@@ -36,5 +36,9 @@ config = {
             "type": "Path",
             "nargs": "+",
         },
+        "--arg-using-dash-syntax": {
+            "help": "A fake argument for testing purposes",
+            "nargs": "+",
+        },
     },
 }

--- a/snakebids/tests/mock/config.yaml
+++ b/snakebids/tests/mock/config.yaml
@@ -18,45 +18,45 @@ pybids_inputs:
       - acquisition
       - task
       - run
-      
-    
+
+
 targets_by_analysis_level:
   participant:
     - ''  # if '', then the first rule is run
 
 analysis_levels: &analysis_levels
  - participant
- 
+
 
 parse_args:
 
   bids_dir:
-    help: The directory with the input dataset formatted according 
+    help: The directory with the input dataset formatted according
           to the BIDS standard.
 
   output_dir:
-    help: The directory where the output files 
+    help: The directory where the output files
           should be stored. If you are running group level analysis
           this folder should be prepopulated with the results of the
           participant level analysis.
 
-  analysis_level: 
-    help: Level of the analysis that will be performed. 
+  analysis_level:
+    help: Level of the analysis that will be performed.
     choices: *analysis_levels
 
   --participant_label:
-    help: The label(s) of the participant(s) that should be analyzed. The label 
-          corresponds to sub-<participant_label> from the BIDS spec 
-          (so it does not include "sub-"). If this parameter is not 
-          provided all subjects should be analyzed. Multiple 
+    help: The label(s) of the participant(s) that should be analyzed. The label
+          corresponds to sub-<participant_label> from the BIDS spec
+          (so it does not include "sub-"). If this parameter is not
+          provided all subjects should be analyzed. Multiple
           participants can be specified with a space separated list.
     nargs: '+'
 
   --exclude_participant_label:
-    help: The label(s) of the participant(s) that should be excluded. The label 
-          corresponds to sub-<participant_label> from the BIDS spec 
-          (so it does not include "sub-"). If this parameter is not 
-          provided all subjects should be analyzed. Multiple 
+    help: The label(s) of the participant(s) that should be excluded. The label
+          corresponds to sub-<participant_label> from the BIDS spec
+          (so it does not include "sub-"). If this parameter is not
+          provided all subjects should be analyzed. Multiple
           participants can be specified with a space separated list.
     nargs: '+'
 
@@ -64,4 +64,8 @@ parse_args:
     help: 'Path(s) to a derivatives dataset, for folder(s) that contains multiple derivatives datasets (default: %(default)s) '
     default: False
     type: Path
+    nargs: '+'
+
+  --arg-using-dash-syntax:
+    help: A fake argument for testing purposes
     nargs: '+'

--- a/snakebids/tests/test_app.py
+++ b/snakebids/tests/test_app.py
@@ -110,6 +110,27 @@ class TestArgTypeAnnotation:
         assert app.config["derivatives"][0] == Path.cwd() / "path/to/nowhere"
 
 
+def test_dash_syntax_in_config_cli_args(app: SnakeBidsApp, mocker: MockerFixture):
+    mocker.patch.object(
+        sys,
+        "argv",
+        [
+            "script_name",
+            "path/to/input",
+            "path/to/output",
+            "participant",
+            "--participant-label",
+            "12345",
+            "--arg_using_dash_syntax",
+            "7890",
+        ],
+    )
+    app.parser = app._create_parser()
+    app._parse_args()
+    assert app.config["participant_label"][0] == "12345"
+    assert app.config["arg_using_dash_syntax"][0] == "7890"
+
+
 class TestRunSnakemake:
     @pytest.fixture
     def io_mocks(self, mocker: MockerFixture):


### PR DESCRIPTION
Previously all args were in the form --argument_one. This allows the dash to be used in place of an underscore. This has no effect on what will be printed into the config file, as all dashes (-) are converted to underscores (_) internally.

@akhanf, it would be good to update the arg in #58 to match if this goes through.

Resolves #10
