### PR TITLE
Setup release drafter

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = False
-current_version = 0.4.2
+current_version = 0.4.3
 
 [bumpversion:file:pyproject.toml]
 search = version = "{current_version}"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,43 @@
+name-template: '$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+template: |
+  ## Changes
+
+  $CHANGES
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'breaking'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'maintenance'
+      - 'test'
+  - title: '📝 Documentation'
+    labels:
+      - 'documentation'
+
+exclude-labels:
+  - skip_changelog
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+
+version-resolver:
+  # major:
+  #   labels:
+  #     - 'breaking'
+  minor:
+    labels:
+      - 'breaking'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'maintenance'
+      - 'bug'
+      - 'test'
+      - 'documentation'
+  default: patch

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -15,39 +15,42 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Find current version
-        id: version-check
-        env:
-          next_version: ${{ steps.release-drafter.outputs.name }}
+      - name: Get previous release version
         run: |
-          current_version=`grep 'version = *' pyproject.toml | sed 's/version = //' | tr -d '"'`
-          echo "\nCurrent version: $current_version"
-          echo "Next resolved version: $next_version"
-          if [[ $next_version == $current_version ]]; then
-            echo '::set-output name=commit::false'
+          echo "PREV_VER=$(cat pyproject.toml | grep -o -E '(version\s=\s)([[:punct:]])([0-9]+.[0-9]+.[0-9]+.+)([[:punct:]])' | cut -d ' ' -f 3 | tr -d '"')" >> $GITHUB_ENV
+
+      - name: Get previous bump version
+        env:
+          PREV_VER: ${{ env.PREV_VER }}
+        run: |
+          if [[ "$PREV_VER" != *"-prerelease."* ]]; then
+            echo "OLD_BUMP=0" >> $GITHUB_ENV
           else
-            echo '::set-output name=commit::true'
+            echo "OLD_BUMP=$(echo $PREV_VER | cut -d '.' -f 4)" >> $GITHUB_ENV
           fi
+
+      - name: Bump version
+        env:
+          BUMP_VER: ${{ env.OLD_BUMP }}
+        run: |
+          echo "NEW_BUMP=$(($BUMP_VER + 1))" >> $GITHUB_ENV
 
       - name: Update version in files
         uses: jacobtomlinson/gha-find-replace@master
-        if: steps.version-check.outputs.commit == 'true'
         with:
           include: 'pyproject.toml'
-          find: 'version = "[0-9]+.[0-9]+.[0-9]+"'
-          replace: 'version = "${{ steps.release-drafter.outputs.name }}"'
+          find: 'version = "(?:([0-9]+.[0-9]+.[0-9]+.+)|([0-9]+.[0-9]+.[0-9]+))"'
+          replace: 'version = "${{ steps.release-drafter.outputs.name }}-prerelease.${{ env.NEW_BUMP }}"'
 
       - name: Commit updates
-        if: steps.version-check.outputs.commit == 'true'
         env:
-          SNAKEBIDS_VERSION: ${{ steps.release-drafter.outputs.name }}
+          SNAKEBIDS_VERSION: ${{ steps.release-drafter.outputs.name }}-prerelease.${{ env.NEW_BUMP }}
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git commit -m "Bump version to $SNAKEBIDS_VERSION" -a
+          git diff-index --quiet HEAD || git commit -m "Bump version to $SNAKEBIDS_VERSION" -a
 
       - name: Push changes
-        if: steps.version-check.outputs.commit == 'true'
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Get previous release version
         run: |
-          echo "PREV_VER=$(cat pyproject.toml | grep -o -E '(version\s=\s)([[:punct:]])([0-9]+.[0-9]+.[0-9]+.+)([[:punct:]])' | cut -d ' ' -f 3 | tr -d '"')" >> $GITHUB_ENV
+          echo "PREV_VER=$(cat pyproject.toml | grep -o -E '(version\s=\s)([[:punct:]])([0-9]+\.[0-9]+\.[0-9]+.+)([[:punct:]])' | cut -d ' ' -f 3 | tr -d '"')" >> $GITHUB_ENV
 
       - name: Get previous bump version
         env:
@@ -39,7 +39,7 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@master
         with:
           include: 'pyproject.toml'
-          find: 'version = "(?:([0-9]+.[0-9]+.[0-9]+.+)|([0-9]+.[0-9]+.[0-9]+))"'
+          find: 'version = "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
           replace: 'version = "${{ steps.release-drafter.outputs.name }}-prerelease.${{ env.NEW_BUMP }}"'
 
       - name: Commit updates

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -8,13 +8,47 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Bump version and push tag
-        uses: jaumann/github-bumpversion-action@v0.0.7
+
+      - name: Update changelog
+        uses: release-drafter/release-drafter@v5
+        id: release-drafter
         env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Find current version
+        id: version-check
+        env:
+          next_version: ${{ steps.release-drafter.outputs.name }}
+        run: |
+          current_version=`grep 'version = *' pyproject.toml | sed 's/version = //' | tr -d '"'`
+          echo "\nCurrent version: $current_version"
+          echo "Next resolved version: $next_version"
+          if [[ $next_version == $current_version ]]; then
+            echo '::set-output name=commit::false'
+          else
+            echo '::set-output name=commit::true'
+          fi
+
+      - name: Update version in files
+        uses: jacobtomlinson/gha-find-replace@master
+        if: steps.version-check.outputs.commit == 'true'
+        with:
+          include: 'pyproject.toml'
+          find: 'version = "[0-9]+.[0-9]+.[0-9]+"'
+          replace: 'version = "${{ steps.release-drafter.outputs.name }}"'
+
+      - name: Commit updates
+        if: steps.version-check.outputs.commit == 'true'
+        env:
+          SNAKEBIDS_VERSION: ${{ steps.release-drafter.outputs.name }}
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -m "Bump version to $SNAKEBIDS_VERSION" -a
+
       - name: Push changes
+        if: steps.version-check.outputs.commit == 'true'
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           tags: false
-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,9 +25,9 @@ jobs:
           echo "Date: ${{ github.event.inputs.date }}"
           echo "Comments: ${{ github.event.inputs.comments }}"
 
-        uses: actions/checkout@master
+      - uses: actions/checkout@master
         with:
-          ref: refs/heads/master
+          ref: refs/heads/main
 
       - name: Draft change log
         uses: release-drafter/release-drafter@v5
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
         with:
-          ref: refs/heads/master
+          ref: refs/heads/main
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@master
         with:
           include: 'pyproject.toml'
-          find: 'version = "(?:([0-9]+.[0-9]+.[0-9]+.+)|([0-9]+.[0-9]+.[0-9]+))"'
+          find: 'version = "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
           replace: 'version = "${{ steps.release-drafter.outputs.name }}"'
 
       - name: Commit updates

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,92 @@
+name: Deploy workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      author:
+        description: "Author"
+        required: true
+        default: "github-actions[bot] (user publishing release)"
+      date:
+        description: "Date"
+        required: true
+        default: "YYYY-MM-DD"
+      comments:
+        description: "Comments"
+
+jobs:
+  release_changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Print author
+        run: |
+          echo "Author: ${{ github.event.inputs.author }}"
+          echo "Date: ${{ github.event.inputs.date }}"
+          echo "Comments: ${{ github.event.inputs.comments }}"
+
+        uses: actions/checkout@master
+        with:
+          ref: refs/heads/master
+
+      - name: Draft change log
+        uses: release-drafter/release-drafter@v5
+        id: release-drafter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update version in files
+        uses: jacobtomlinson/gha-find-replace@master
+        with:
+          include: 'pyproject.toml'
+          find: 'version = "(?:([0-9]+.[0-9]+.[0-9]+.+)|([0-9]+.[0-9]+.[0-9]+))"'
+          replace: 'version = "${{ steps.release-drafter.outputs.name }}"'
+
+      - name: Commit updates
+        env:
+          LATEST_VERSION: ${{ steps.release-drafter.outputs.name }}
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git diff-index --quiet HEAD || git commit -m "Bump version to $LATEST_VERSION" -a
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish change log
+        uses: release-drafter/release-drafter@v5
+        with:
+          publish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [release_changelog]
+
+    steps:
+      - uses: actions/checkout@master
+        with:
+          ref: refs/heads/master
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+
+      #----------------------------------------------
+      #  -----  install & configure poetry  -----
+      #----------------------------------------------
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Build and publish
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          poetry publish --build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Test and deploy workflow
+name: Test workflow
 
 on:
   push:
@@ -112,26 +112,3 @@ jobs:
     - name: Test with pytest
       run: |
         poetry run pytest --doctest-modules --ignore=docs --ignore=project_template
-
-  deploy:
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    needs: [ 'test' ]
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-    #----------------------------------------------
-    #  -----  install & configure poetry  -----
-    #----------------------------------------------
-    - name: Install Poetry
-      uses: snok/install-poetry@v1
-      with:
-        virtualenvs-create: true
-        virtualenvs-in-project: true
-
-    - name: Build and publish
-      env:
-        POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
-      run: |
-        poetry publish --build

--- a/project_template/cookiecutter.json
+++ b/project_template/cookiecutter.json
@@ -5,5 +5,5 @@
   "app_full_name": "My BIDS App",
   "app_name": "{{ cookiecutter.app_full_name.lower().replace(' ', '_').replace('-', '_') }}",
   "app_description": "My template snakebids app.",
-  "snakebids_version": "0.4.2"
+  "snakebids_version": "0.4.3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "snakebids"
-version = "0.4.2"
+version = "0.4.3"
 description = "BIDS integration into snakemake workflows"
 readme = "README.rst"
 repository = "https://github.com/akhanf/snakebids"


### PR DESCRIPTION
This PR (based on `0.4.0`) starts to incorporate the `release-drafter` into the github actions workflow. This adds the following functionality. 

- [x] Resolve version by label
- [x] Automatic version bumping using resolved version (uses existing `bump_version.yml` workflow)
- [x] Add missing labels

The labels (if missing or there are others we wish to include) still need to be added to the repo.

Resolves #72. Note, the `release-drafter` won't actually start to work until it is merged into `main` and will cause the CI for this branch to fail until merged. 
