### PR TITLE
Rename release-drafter workflow 

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       
       - name: Check PR label
-        uses: danielchabr/pr-labels-checker@v3
+        uses: danielchabr/pr-labels-checker@v3.1
         id: check-label
         with:
           hasNone: skip_changelog

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -1,4 +1,4 @@
-name: Bump version
+name: Manual release-drafter update
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Quick patch to rename the release-drafter workflow. Missed the fact it was named the same as `bump_version` workflow. 

Also uses this PR to fix the `pr-label-checker` action that was using the wrong tag.