### PR TITLE
Refactor app.py

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -226,7 +226,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "distlib"
-version = "0.3.3"
+version = "0.3.4"
 description = "Distribution utilities"
 category = "dev"
 optional = false
@@ -1103,7 +1103,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "snakemake"
-version = "6.12.1"
+version = "6.12.2"
 description = "Snakemake is a workflow management system that aims to reduce the complexity of creating workflows by providing a fast and comfortable execution environment, together with a clean and modern specification language in python style. Snakemake workflows are essentially Python scripts extended by declarative code to define rules. Rules describe how to create output files from input files."
 category = "main"
 optional = false
@@ -1244,7 +1244,7 @@ python-versions = "*"
 
 [[package]]
 name = "ubelt"
-version = "0.10.1"
+version = "0.10.2"
 description = "A Python utility belt containing simple tools, a stdlib like feel, and extra batteries."
 category = "dev"
 optional = false
@@ -1334,7 +1334,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.11"
-content-hash = "ce815ae31b99fcf34ffe122c7cc7bc4853f84fa9d48de84788a040490ccd55cc"
+content-hash = "f9dce78b2bf891b1466d80cefdce9b79d1695a443e70292440028e5c439be9a6"
 
 [metadata.files]
 appdirs = [
@@ -1440,8 +1440,8 @@ datrie = [
     {file = "datrie-0.8.2.tar.gz", hash = "sha256:525b08f638d5cf6115df6ccd818e5a01298cd230b2dac91c8ff2e6499d18765d"},
 ]
 distlib = [
-    {file = "distlib-0.3.3-py2.py3-none-any.whl", hash = "sha256:c8b54e8454e5bf6237cc84c20e8264c3e991e824ef27e8f1e81049867d861e31"},
-    {file = "distlib-0.3.3.zip", hash = "sha256:d982d0751ff6eaaab5e2ec8e691d949ee80eddf01a62eaa96ddb11531fe16b05"},
+    {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
+    {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
 ]
 docopt = [
     {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},
@@ -1970,7 +1970,7 @@ smmap = [
     {file = "smmap-5.0.0.tar.gz", hash = "sha256:c840e62059cd3be204b0c9c9f74be2c09d5648eddd4580d9314c3ecde0b30936"},
 ]
 snakemake = [
-    {file = "snakemake-6.12.1.tar.gz", hash = "sha256:6bc45e98c0cd90d8e696ff09ad87cddf815baf50bd75964ea01639c9699ca50d"},
+    {file = "snakemake-6.12.2.tar.gz", hash = "sha256:2e63e239a4cbba0c0432bb24f7a3b59063da9cc8e90537e28e73350c10190d7d"},
 ]
 sqlalchemy = [
     {file = "SQLAlchemy-1.3.24-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:87a2725ad7d41cd7376373c15fd8bf674e9c33ca56d0b8036add2d634dba372e"},
@@ -2066,9 +2066,10 @@ typing-extensions = [
     {file = "typing_extensions-3.10.0.2.tar.gz", hash = "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e"},
 ]
 ubelt = [
-    {file = "ubelt-0.10.1-py2.py3-none-any.whl", hash = "sha256:abf633e4a0a9dec5276aef01ba1beec211f9634ae859bd480d54946d8f730d7a"},
-    {file = "ubelt-0.10.1-py3-none-any.whl", hash = "sha256:56444d834c86990875b96c994e7adf5f5b5a98ec953ff7185084ab04384933b9"},
-    {file = "ubelt-0.10.1.tar.gz", hash = "sha256:406898bb6cf24871185be455a3a65c2da80fd9edbc471de732382be35c86c681"},
+    {file = "ubelt-0.10.2-py2-none-any.whl", hash = "sha256:ced4933d3b8a6239f6e01c82612b80182f4db688056fa6be0562bdf9adf8b52d"},
+    {file = "ubelt-0.10.2-py2.py3-none-any.whl", hash = "sha256:0b0c1b3f6b8d770b798efea747f138f0cddb93e6d42de59d1eff9bc326a7c402"},
+    {file = "ubelt-0.10.2-py3-none-any.whl", hash = "sha256:0ba15d8bb35c27b751225812805169ea1e97e6aad05080362e8683e48d45bf15"},
+    {file = "ubelt-0.10.2.tar.gz", hash = "sha256:1d7a84a58f540796c0aadca506ea02a279a53a4b802088def1ce9d808c160711"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.7-py2.py3-none-any.whl", hash = "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ cookiecutter = "^1.7.2"
 colorama = "^0.4.4"
 typing-extensions = "^3.10.0"
 progress = "^1.6"
+attrs = "^21.2.0"
 
 [tool.poetry.dev-dependencies]
 black = "^21.10b0"

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -76,10 +76,6 @@ class SnakeBidsApp:
     snakemake_dir : str
         Root directory of the snakebids app, containing the config file and workflow
         files.
-    skip_parse_args : bool, optional
-        @DEPRECATED (This argument currently has no functionality). If true, the
-        Snakebids app will not attempt to parse input arguments, and will only handle
-        the config file. (default: False)
     parser : ArgumentParser, optional
         Parser including only the arguments specific to this Snakebids app, as specified
         in the config file. By default, it will use `create_parser()` from `cli.py`
@@ -119,13 +115,6 @@ class SnakeBidsApp:
         Workflow snakefile will read snakebids config, create inputs_config,
         and read that in.
         """
-
-        # Issue deprecation warning for skip_parse_args
-        if self.skip_parse_args:
-            logger.warning(
-                "[DEPRECATION WARNING]: skip_parse_args will not have any effect on"
-                "this app. It will be removed in a future version"
-            )
 
         # If no SnakebidsArgs were provided on class instantiation, we compute args
         # using the provided parser

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -2,16 +2,21 @@
 
 import argparse
 import logging
-import os
-import pathlib
-import re
-import subprocess
 import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
+import attr
 import snakemake
 from colorama import Fore
 from snakemake.io import load_configfile
 
+from snakebids.cli import (
+    SnakebidsArgs,
+    add_dynamic_args,
+    create_parser,
+    parse_snakebids_args,
+)
 from snakebids.exceptions import ConfigError, RunError
 from snakebids.utils.output import (
     prepare_output,
@@ -20,96 +25,7 @@ from snakebids.utils.output import (
     write_output_mode,
 )
 
-# We define Path here in addition to pathlib to put both variables in globals()
-# This way, users specifying a path type in their config.yaml can indicate
-# either Path or pathlib.Path
-Path = pathlib.Path
-
 logger = logging.Logger(__name__)
-
-
-# pylint: disable=too-few-public-methods,
-class KeyValue(argparse.Action):
-    """Class for accepting key=value pairs in argparse"""
-
-    # Constructor calling
-    def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, self.dest, {})
-
-        for value in values:
-            # split it into key and value
-            key, value = value.split("=")
-            # assign into dictionary
-            getattr(namespace, self.dest)[key] = value
-
-
-# pylint: disable=too-few-public-methods
-class SnakemakeHelpAction(argparse.Action):
-    """Class for printing snakemake usage in argparse"""
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        run("snakemake -h")
-        sys.exit(0)
-
-
-def run(command, env=None):
-    """Helper function for running a system command while merging
-    stderr/stdout to stdout.
-
-    Parameters
-    ----------
-    command : list of str
-        command to run
-
-    env : dict, optional
-        environment variable to set before running the command
-    """
-    if env is None:
-        env = {}
-
-    merged_env = os.environ
-    merged_env.update(env)
-    # pylint: disable=consider-using-with
-    process = subprocess.Popen(
-        command,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        shell=True,
-        env=merged_env,
-    )
-    while True:
-        line = process.stdout.readline()
-        line = str(line, "utf-8")[:-1]
-        print(line)
-        if line == "" and process.poll() is not None:
-            break
-    if process.returncode != 0:
-        raise Exception(f"Non zero return code: {process.returncode}")
-
-
-def resolve_path(path_candidate):
-    """Helper function to resolve any paths or list
-    of paths it's passed. Otherwise, returns the argument
-    unchanged.
-
-    Parameters
-    ----------
-    command : list, os.Pathlike, object
-        command to run
-
-    Returns
-    -------
-    list, os.Pathlike, object
-        If os.Pathlike or list  of os.Pathlike, the same paths resolved.
-        Otherwise, the argument unchanged.
-    """
-    if isinstance(path_candidate, list):
-        return [resolve_path(p) for p in path_candidate]
-
-    if isinstance(path_candidate, os.PathLike):
-        return path_candidate.resolve()
-
-    return path_candidate
 
 
 SNAKEFILE_CHOICES = [
@@ -136,317 +52,66 @@ CONFIGFILE_CHOICES = [
 ]
 
 
-# pylint: disable=too-few-public-methods, too-many-instance-attributes
+def _get_file_paths(choices: List[str], file_name: str):
+    def wrapper(self: "SnakeBidsApp"):
+        # look for snakebids.yml in the snakemake_dir, quit if not found
+        for path in choices:
+            if (self.snakemake_dir / path).exists():
+                return Path(self.snakemake_dir, path)
+        raise ConfigError(
+            f"Error: no {file_name} file found, tried {', '.join(CONFIGFILE_CHOICES)}."
+        )
+
+    return wrapper
+
+
+# pylint: disable=unsubscriptable-object, unsupported-assignment-operation,
+# pylint: disable=too-few-public-methods
+@attr.define(slots=False)
 class SnakeBidsApp:
     """Snakebids app with config and arguments.
 
-    Parameters
-    ----------
-    snakemake_dir : str
-        Root directory of the snakebids app, containing the config file and
-        workflow files.
-    skip_parse_args : bool, optional
-        If true, the Snakebids app will not attempt to parse input arguments,
-        and will only handle the config file.
-    out_configfile : str
-        Path to the updated configfile (YAML or JSON), relative to the output
-        working directory. This should be the same as the `configfile: ` used
-        in your workflow. (default: 'config/snakebids.yml')
-
     Attributes
     ----------
-    config : dict
+    snakemake_dir : str
+        Root directory of the snakebids app, containing the config file and workflow
+        files.
+    skip_parse_args : bool, optional
+        @DEPRECATED (This argument currently has no functionality). If true, the
+        Snakebids app will not attempt to parse input arguments, and will only handle
+        the config file. (default: False)
+    parser : ArgumentParser, optional
+        Parser including only the arguments specific to this Snakebids app, as specified
+        in the config file. By default, it will use `create_parser()` from `cli.py`
+    configfile_path : str, optional
+        Relative path to config file (relative to snakemake_dir). By default,
+        autocalculates based on snamake_dir
+    snakefile_path : str, optional
+        Absolute path to the input Snakefile. By default, autocalculates based on
+        snakemake_dir
+            join(snakemake_dir, snakefile_path)
+    config : dict, optional
         Contains all the configuration variables parsed from the config file
         and generated during the initialization of the SnakeBidsApp.
-    parser_include_snakemake : ArgumentParser
-        Parser including the generic Snakemake parser as a parent. This will
-        contain all arguments a Snakemake app can receive.
-    parser : ArgumentParser
-        Parser including only the arguments specific to this Snakebids app, as
-        specified in the config file.
-    snakefile : str
-        Absolute path to the input Snakefile
-            join(snakemake_dir, snakefile_path)
-    configfile_path : str
-        Relative path to config file (relative to snakemake_dir)
-    updated_config : str
-        Absolute path to the updated config file to write.
-    workflow_mode : bool
-        If true, produces output in workflow mode, otherwise snakemake mode.
-    force : bool
-        If false, prevents conversion of output from workflow mode to bidsapp mode.
-    outputdir : Path
-        Path to outputdir specified by user
-    retrofit : bool
-        If true, run_snakemake will attempt to convert legacy output format into bidsapp
-        format.
+    args : SnakebidsArgs, optional
+        Arguments to use when running the app. By default, generated using the parser
+        attribute, autopopulated with args from `config.py`
     """
 
-    outputdir: Path
-    snakemake_dir: Path
-
-    def __init__(self, snakemake_dir, skip_parse_args=False):
-        # input argument is the dir where snakemake would be run
-        # we use this to locate the config file, and snakefile adding them to
-        # generated_config and also add the snakemake_dir to the
-        # generated_config, so the workflow can use it to source files from
-        # it (e.g. atlases etc..)
-
-        self.snakemake_dir = Path(snakemake_dir).resolve()
-
-        # look for snakebids.yml in the snakemake_dir, quit if not found
-        self.configfile_path = ""
-        for path in CONFIGFILE_CHOICES:
-            if (self.snakemake_dir / path).exists():
-                self.configfile_path = path
-                break
-        if not self.configfile_path:
-            raise ConfigError(
-                f"Error: no config file found, tried {', '.join(CONFIGFILE_CHOICES)}."
-            )
-
-        # look for snakefile in the snakemake_dir, quit if not found
-        self.snakefile = None
-        for snakefile_path in SNAKEFILE_CHOICES:
-            if (self.snakemake_dir / snakefile_path).exists():
-                self.snakefile = Path(snakemake_dir, snakefile_path)
-                break
-        if self.snakefile is None:
-            raise ConfigError(
-                f"Error: no Snakefile found, tried {', '.join(SNAKEFILE_CHOICES)}."
-            )
-
-        self.config = load_configfile(Path(snakemake_dir, self.configfile_path))
-
-        if self.config.get("debug", False):
-            logging.basicConfig(level=logging.DEBUG)
-
-        # add path to snakefile to the config -- so workflows can grab files
-        # relative to the snakefile folder
-        self.config["snakemake_dir"] = snakemake_dir
-        self.config["snakefile"] = self.snakefile
-
-        self.parser_include_snakemake = self._create_parser(include_snakemake=True)
-        self.parser = self._create_parser()
-
-        if not skip_parse_args:
-            self._parse_args()
-
-    # pylint: disable=too-many-locals
-    def _create_parser(self, include_snakemake=False):
-        """Create a parser with snakemake parser as parent solely for
-        displaying help and checking conflicts, but then for actual parsing
-        use snakebids parser to parse known args, then pass remaining to
-        snakemake.
-        """
-
-        if include_snakemake:
-            # get snakemake parser
-            smk_parser = snakemake.get_argument_parser()
-
-            # create parser
-            parser = argparse.ArgumentParser(
-                description="Snakebids helps build BIDS Apps with Snakemake",
-                add_help=False,
-                parents=[smk_parser],
-            )
-        else:
-            parser = argparse.ArgumentParser(
-                description="Snakebids helps build BIDS Apps with Snakemake"
-            )
-
-        parser.add_argument(
-            "--workflow-mode",
-            "--workflow_mode",
-            "-W",
-            action="store_true",
-            help=(
-                "Run Snakebids in Workflow mode. This will cause the entire Snakebids "
-                "app, except for the results folder, to be copied into your "
-                "output_dir. Snakemake will be run in this new child app, and results "
-                "will be put in output_dir/results."
-            ),
-        )
-
-        # We use -x as the alias because both -f and -F are taken by snakemake
-        parser.add_argument(
-            "--force-conversion",
-            "--force_conversion",
-            "-x",
-            action="store_true",
-            help=(
-                "Force snakebids to convert a workflow output to a bidsapp output. "
-                "conversion will delete all the files in the workflow snakebids app."
-            ),
-        )
-
-        parser.add_argument(
-            "--retrofit",
-            action="store_true",
-            help=(
-                "Convert a legacy Snakebids output (Snakebids 0.3.x or lower) into "
-                "bidsapp mode. This will delete any config files currently in the "
-                "output."
-            ),
-        )
-
-        # add option for printing out snakemake usage
-        parser.add_argument(
-            "--help-snakemake",
-            "--help_snakemake",
-            nargs=0,
-            action=SnakemakeHelpAction,
-            help=(
-                "Options to Snakemake can also be passed directly at the "
-                "command-line, use this to print Snakemake usage"
-            ),
-        )
-
-        # create parser group for app options
-        app_group = parser.add_argument_group("SNAKEBIDS", "Options for snakebids app")
-
-        # update the parser with config options
-        for name, parse_args in self.config["parse_args"].items():
-            # Convert type annotations from strings to class types
-            # We first check that the type annotation is, in fact,
-            # a str to allow the edge case where it's already
-            # been converted
-            if "type" in parse_args and isinstance(parse_args["type"], str):
-                try:
-                    parse_args["type"] = globals()[parse_args["type"]]
-                except KeyError as err:
-                    raise TypeError(
-                        f"{parse_args['type']} is not available "
-                        + f"as a type for {name}"
-                    ) from err
-
-            if re.match(r"^--", name):
-                name_part = re.match(r"^--(.+)$", name).group(1)
-                names = (
-                    name,
-                    re.sub(r"\_", "-", name),
-                    f"--{re.sub(r'-', '_', name_part)}",
-                )
-            else:
-                names = (name,)
-            app_group.add_argument(*set(names), **parse_args)
-
-        # general parser for
-        # --filter_{input_type} {key1}={value1} {key2}={value2}...
-        # create filter parsers, one for each input_type
-        filter_opts = parser.add_argument_group(
-            "BIDS FILTERS",
-            "Filters to customize PyBIDS get() as key=value pairs",
-        )
-
-        for input_type in self.config["pybids_inputs"].keys():
-            argnames = (f"--filter_{input_type}", f"--filter-{input_type}")
-            arglist_default = [
-                f"{key}={value}"
-                for (key, value) in self.config["pybids_inputs"][input_type][
-                    "filters"
-                ].items()
-            ]
-            arglist_default_string = " ".join(arglist_default)
-
-            filter_opts.add_argument(
-                *argnames,
-                nargs="+",
-                action=KeyValue,
-                help=f"(default: {arglist_default_string})",
-            )
-
-        # general parser for
-        # --wildcards_{input_type} {wildcard1} {wildcard2} ...
-        # create wildcards parsers, one for each input_type
-        wildcards_opts = parser.add_argument_group(
-            "INPUT WILDCARDS",
-            "File path entities to use as wildcards in snakemake",
-        )
-
-        for input_type in self.config["pybids_inputs"].keys():
-            argnames = (f"--wildcards-{input_type}", f"--wildcards_{input_type}")
-            arglist_default = [
-                f"{wc}" for wc in self.config["pybids_inputs"][input_type]["wildcards"]
-            ]
-            arglist_default_string = " ".join(arglist_default)
-
-            wildcards_opts.add_argument(
-                *argnames,
-                nargs="+",
-                help=f"(default: {arglist_default_string})",
-            )
-
-        override_opts = parser.add_argument_group(
-            "PATH OVERRIDE",
-            (
-                "Options for overriding BIDS by specifying absolute paths "
-                "that include wildcards, e.g.: "
-                "/path/to/my_data/{subject}/t1.nii.gz"
-            ),
-        )
-
-        # create path override parser
-        for input_type in self.config["pybids_inputs"].keys():
-            argnames = (f"--path-{input_type}", f"--path_{input_type}")
-            override_opts.add_argument(*argnames, default=None)
-
-        return parser
-
-    def _parse_args(self):
-
-        # use snakebids parser to parse the known arguments
-        # will pass the rest of args when running snakemake
-        all_args = self.parser.parse_known_args()
-
-        args = all_args[0]
-        snakemake_args = all_args[1]
-        # resolve all path items to get absolute paths
-        args.__dict__ = {k: resolve_path(v) for k, v in args.__dict__.items()}
-
-        self.workflow_mode = args.workflow_mode
-        self.force = args.force_conversion
-        self.outputdir = Path(args.output_dir).resolve()
-        self.retrofit = args.retrofit
-
-        # add snakebids arguments to config
-        self.config.update(args.__dict__)
-
-        # add snakemake arguments to config
-        self.config.update({"snakemake_args": snakemake_args})
-
-        # argparse adds filter_{input_type} to the config
-        # we want to update the pybids_inputs dict with this, then remove the
-        # filter_{input_type} dict
-        for input_type in self.config["pybids_inputs"].keys():
-            arg_filter_dict = self.config[f"filter_{input_type}"]
-            if arg_filter_dict is not None:
-                self.config["pybids_inputs"][input_type]["filters"].update(
-                    arg_filter_dict
-                )
-            del self.config[f"filter_{input_type}"]
-
-        # add cmdline defined wildcards from the list:
-        # wildcards_{input_type}
-        for input_type in self.config["pybids_inputs"].keys():
-            wildcards_list = self.config[f"wildcards_{input_type}"]
-            if wildcards_list is not None:
-                self.config["pybids_inputs"][input_type]["wildcards"] += wildcards_list
-            del self.config[f"wildcards_{input_type}"]
-
-        # add custom input paths to
-        # config['pybids_inputs'][input_type]['custom_path']
-        for input_type in self.config["pybids_inputs"].keys():
-            custom_path = self.config[f"path_{input_type}"]
-            if custom_path is not None:
-                self.config["pybids_inputs"][input_type]["custom_path"] = Path(
-                    custom_path
-                ).resolve()
-            del self.config[f"path_{input_type}"]
-
-        # replace paths with realpaths
-        self.config["bids_dir"] = Path(self.config["bids_dir"]).resolve()
-        self.config["output_dir"] = Path(self.config["output_dir"]).resolve()
+    snakemake_dir: Path = attr.ib(converter=lambda path: Path(path).resolve())
+    skip_parse_args: bool = False
+    parser: argparse.ArgumentParser = create_parser()
+    configfile_path: Path = attr.Factory(
+        _get_file_paths(CONFIGFILE_CHOICES, "config"), takes_self=True
+    )
+    snakefile_path: Path = attr.Factory(
+        _get_file_paths(SNAKEFILE_CHOICES, "Snakefile"), takes_self=True
+    )
+    config: Dict[str, Any] = attr.Factory(
+        lambda self: load_configfile(self.snakemake_dir / self.configfile_path),
+        takes_self=True,
+    )
+    args: Optional[SnakebidsArgs] = None
 
     def run_snakemake(self):
         """Run snakemake with that config.
@@ -455,74 +120,152 @@ class SnakeBidsApp:
         and read that in.
         """
 
-        if self.snakemake_dir == self.outputdir:
-            write_output_mode(self.outputdir / ".snakebids", "workflow")
+        # Issue deprecation warning for skip_parse_args
+        if self.skip_parse_args:
+            logger.warning(
+                "[DEPRECATION WARNING]: skip_parse_args will not have any effect on"
+                "this app. It will be removed in a future version"
+            )
+
+        # If no SnakebidsArgs were provided on class instantiation, we compute args
+        # using the provided parser
+        if self.args:
+            args = self.args
+        else:
+            # Dynamic args include --filter-... and --wildcards-... . They depend on the
+            # config
+            add_dynamic_args(
+                self.parser, self.config["parse_args"], self.config["pybids_inputs"]
+            )
+            args = parse_snakebids_args(self.parser)
+
+        # If the snakemake_dir is the same as the outputdir, we need to switch into
+        # workflow mode
+        if self.snakemake_dir == args.outputdir:
+            write_output_mode(args.outputdir / ".snakebids", "workflow")
             mode = "workflow"
+            # The new config file will inevitably have the same path as the old, so we
+            # allow overwriting
             force_config_overwrite = True
-            if not self.workflow_mode:
+
+            # Print a friendly warning if the user didn't specify workflow mode
+            if not args.workflow_mode:
                 print(
                     f"{Fore.YELLOW}You specified your output to be in the snakebids "
                     "directory, so we're switching automatically to workflow mode!\n"
                     f"{Fore.RESET}You'll find your results in "
                     f"`{(self.snakemake_dir/'results').resolve()}`"
                 )
-        else:
-            mode = "workflow" if self.workflow_mode else "bidsapp"
-            force_config_overwrite = False
-            if self.retrofit:
-                for path in CONFIGFILE_CHOICES:
-                    if (self.outputdir / path).exists():
-                        self.configfile_path = path
-                if not retrofit_output(
-                    self.outputdir,
-                    # Find all config files in the outputdir
-                    (
-                        self.outputdir / p
-                        for p in CONFIGFILE_CHOICES
-                        if (self.outputdir / p).exists()
-                    ),
-                ):
-                    print(f"{Fore.YELLOW}Exiting. No conversion performed.{Fore.RESET}")
-                    sys.exit(1)
 
+        # Otherwise, both workflow and bidsapp mode are possible
+        else:
+            mode = "workflow" if args.workflow_mode else "bidsapp"
+            # Disable config_overwrite to prevent accidental file modification
+            # This will be set to true in the case of bidsapp mode
+            force_config_overwrite = False
+
+            # If the user asked to retrofit, we attempt it
+            if args.retrofit and not retrofit_output(
+                args.outputdir,
+                # Find all config files in the outputdir
+                (
+                    args.outputdir / p
+                    for p in CONFIGFILE_CHOICES
+                    if (args.outputdir / p).exists()
+                ),
+            ):
+                # If we get here, there was an error in retrofitting
+                print(f"{Fore.YELLOW}Exiting. No conversion performed.{Fore.RESET}")
+                sys.exit(1)
+
+        # Attempt to prepare the output folder. Anything going wrong will raise a
+        # RunError, as described in the docstring
         try:
-            root = prepare_output(self.snakemake_dir, self.outputdir, mode, self.force)
+            root = prepare_output(self.snakemake_dir, args.outputdir, mode, args.force)
         except RunError as err:
             print(err.msg)
             sys.exit(1)
 
+        # Update our config file:
+        # - Add path to snakefile to the config so workflows can grab files relative to
+        #    the snakefile folder
+        # - Add info from args
+        # - Set mode (bidsapp or workflow) and output_dir appropriately
+        self.config["snakemake_dir"] = self.snakemake_dir
+        self.config["snakefile"] = self.snakefile_path
+        update_config(self.config, args)
         if mode == "workflow":
             self.config["output_dir"] = str(root)
             self.config["root"] = "results"
-            new_config_file = self.outputdir / self.configfile_path
         else:
             force_config_overwrite = True
             self.config["root"] = ""
-            new_config_file = self.outputdir / self.configfile_path
 
-        cwd = self.outputdir
+        # Write the config file
+        new_config_file = args.outputdir / self.configfile_path
+        write_config_file(
+            config_file=new_config_file,
+            data=self.config,
+            force_overwrite=force_config_overwrite,
+        )
 
-        write_config_file(new_config_file, self.config, force_config_overwrite)
-
-        # running the chosen participant level
-        analysis_level = self.config["analysis_level"]
-
-        # run snakemake (passing any leftover args from argparse)
+        # Run snakemake (passing any leftover args from argparse)
         # Filter any blank strings before submitting
-        snakemake_argv = [
-            *filter(
-                None,
-                [
-                    "--snakefile",
-                    str(self.snakefile),
-                    "--directory",
-                    str(cwd),
-                    "--configfile",
-                    str(new_config_file.resolve()),
-                    *self.config["snakemake_args"],
-                    *self.config["targets_by_analysis_level"][analysis_level],
-                ],
-            )
-        ]
+        snakemake.main(
+            [
+                *filter(
+                    None,
+                    [
+                        "--snakefile",
+                        str(self.snakefile_path),
+                        "--directory",
+                        str(args.outputdir),
+                        "--configfile",
+                        str(new_config_file.resolve()),
+                        *self.config["snakemake_args"],
+                        *self.config["targets_by_analysis_level"][
+                            self.config["analysis_level"]
+                        ],
+                    ],
+                )
+            ]
+        )
 
-        snakemake.main(snakemake_argv)
+
+def update_config(config: Dict[str, Any], snakebids_args: SnakebidsArgs):
+    # add snakemake arguments to config
+    config.update({"snakemake_args": snakebids_args.snakemake_args})
+
+    # argparse adds filter_{input_type}
+    # we want to update the pybids_inputs dict with this, then remove the
+    # filter_{input_type} dict
+    pybids_inputs = config["pybids_inputs"]
+    args = snakebids_args.args_dict
+    for input_type in pybids_inputs.keys():
+        arg_filter_dict = args[f"filter_{input_type}"]
+        if arg_filter_dict is not None:
+            pybids_inputs[input_type]["filters"].update(arg_filter_dict)
+        del args[f"filter_{input_type}"]
+
+    # add cmdline defined wildcards from the list:
+    # wildcards_{input_type}
+    for input_type in pybids_inputs.keys():
+        wildcards_list = args[f"wildcards_{input_type}"]
+        if wildcards_list is not None:
+            pybids_inputs[input_type]["wildcards"] += wildcards_list
+        del args[f"wildcards_{input_type}"]
+
+    # add custom input paths to
+    # config['pybids_inputs'][input_type]['custom_path']
+    for input_type in pybids_inputs.keys():
+        custom_path = args[f"path_{input_type}"]
+        if custom_path is not None:
+            pybids_inputs[input_type]["custom_path"] = Path(custom_path).resolve()
+        del args[f"path_{input_type}"]
+
+    # add snakebids arguments to config
+    config.update(args)
+
+    # replace paths with realpaths
+    config["bids_dir"] = Path(config["bids_dir"]).resolve()
+    config["output_dir"] = Path(config["output_dir"]).resolve()

--- a/snakebids/bids.py
+++ b/snakebids/bids.py
@@ -7,6 +7,7 @@ import re
 from collections import OrderedDict
 from os.path import join
 from pathlib import Path
+from typing import Optional
 
 from bids import BIDSLayout, BIDSLayoutIndexer
 
@@ -143,7 +144,7 @@ def bids(
     entities = {k.replace("_", ""): v for k, v in entities.items()}
 
     # strict ordering of bids entities is specified here:
-    order = OrderedDict(
+    order: OrderedDict[str, Optional[str]] = OrderedDict(
         [
             ("task", None),
             ("acq", None),

--- a/snakebids/cli.py
+++ b/snakebids/cli.py
@@ -1,0 +1,295 @@
+import argparse
+import os
+import pathlib
+import re
+from typing import Any, Dict, List
+
+import attr
+import snakemake
+
+# We define Path here in addition to pathlib to put both variables in globals()
+# This way, users specifying a path type in their config.yaml can indicate
+# either Path or pathlib.Path
+Path = pathlib.Path
+
+
+# pylint: disable=too-few-public-methods,
+class KeyValue(argparse.Action):
+    """Class for accepting key=value pairs in argparse"""
+
+    # Constructor calling
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, {})
+
+        for value in values:
+            # split it into key and value
+            key, value = value.split("=")
+            # assign into dictionary
+            getattr(namespace, self.dest)[key] = value
+
+
+# pylint: disable=too-few-public-methods
+class SnakemakeHelpAction(argparse.Action):
+    """Class for printing snakemake usage in argparse"""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        snakemake.main(["-h"])
+
+
+# pylint: disable=missing-class-docstring
+@attr.frozen
+class SnakebidsArgs:
+    """Arguments for Snakebids App
+
+    Organizes the various options available for a generic Snakebids App, and store
+    project specific arguments in a dict. Snakemake args are to be put in a list
+
+    Attributes
+    ----------
+    workflow_mode : bool
+        Indicates whether to run in workflow mode. False maps to bidsapp mode
+    force : bool
+        Force conversion from workflow apps to bidsapp apps, resulting in potential
+        data loss
+    outputdir : Path
+        Directory to place outputs
+    retrofit : Path
+        Convert a legacy snakebids app to the new style
+    snakemake_args : list of strings
+        Arguments to pass on to Snakemake
+    args_dict : Dict[str, Any]
+        Contains all the snakebids specific args. Meant to contain custom user args
+        defined in config, as well as dynamic --filter-xx and --wildcard-xx args.
+        These will eventually be printed in the new config.
+    """
+
+    workflow_mode: bool
+    force: bool
+    outputdir: Path
+    retrofit: bool
+    snakemake_args: List[str]
+    args_dict: Dict[str, Any]
+
+
+def create_parser(include_snakemake=False):
+    """Generate basic Snakebids Parser
+
+    Includes the standard Snakebids arguments.
+    """
+
+    # The snakemake parser functionality did not seem to be implemented in the original
+    # factoring. I left the logic here, but it should probably be removed if it's not
+    # needed.
+    if include_snakemake:
+        # get snakemake parser
+        smk_parser = snakemake.get_argument_parser()
+
+        # create parser
+        parser = argparse.ArgumentParser(
+            description="Snakebids helps build BIDS Apps with Snakemake",
+            add_help=False,
+            parents=[smk_parser],
+        )
+    else:
+        parser = argparse.ArgumentParser(
+            description="Snakebids helps build BIDS Apps with Snakemake"
+        )
+
+    standard_group = parser.add_argument_group(
+        "STANDARD", "Standard options for all snakebids apps"
+    )
+
+    standard_group.add_argument(
+        "--workflow-mode",
+        "--workflow_mode",
+        "-W",
+        action="store_true",
+        help=(
+            "Run Snakebids in Workflow mode. This will cause the entire Snakebids "
+            "app, except for the results folder, to be copied into your "
+            "output_dir. Snakemake will be run in this new child app, and results "
+            "will be put in output_dir/results."
+        ),
+    )
+
+    # We use -x as the alias because both -f and -F are taken by snakemake
+    standard_group.add_argument(
+        "--force-conversion",
+        "--force_conversion",
+        "-x",
+        action="store_true",
+        help=(
+            "Force snakebids to convert a workflow output to a bidsapp output. "
+            "conversion will delete all the files in the workflow snakebids app."
+        ),
+    )
+
+    standard_group.add_argument(
+        "--retrofit",
+        action="store_true",
+        help=(
+            "Convert a legacy Snakebids output (Snakebids 0.3.x or lower) into "
+            "bidsapp mode. This will delete any config files currently in the "
+            "output."
+        ),
+    )
+
+    # add option for printing out snakemake usage
+    standard_group.add_argument(
+        "--help-snakemake",
+        "--help_snakemake",
+        nargs=0,
+        action=SnakemakeHelpAction,
+        help=(
+            "Options to Snakemake can also be passed directly at the "
+            "command-line, use this to print Snakemake usage"
+        ),
+    )
+    return parser
+
+
+def add_dynamic_args(
+    parser: argparse.ArgumentParser,
+    parse_args: Dict[str, Dict[str, str]],
+    pybids_inputs: Dict[str, Dict[str, Dict[str, Any]]],
+):
+    # create parser group for app options
+    app_group = parser.add_argument_group("SNAKEBIDS", "Options for snakebids app")
+
+    # update the parser with config options
+    for name, arg in parse_args.items():
+        # Convert type annotations from strings to class types
+        # We first check that the type annotation is, in fact,
+        # a str to allow the edge case where it's already
+        # been converted
+        if "type" in arg and isinstance(arg["type"], str):
+            try:
+                arg["type"] = globals()[arg["type"]]
+            except KeyError as err:
+                raise TypeError(
+                    f"{arg['type']} is not available " + f"as a type for {name}"
+                ) from err
+
+        names = _make_underscore_dash_aliases(name)
+        app_group.add_argument(*names, **arg)
+
+    # general parser for
+    # --filter_{input_type} {key1}={value1} {key2}={value2}...
+    # create filter parsers, one for each input_type
+    filter_opts = parser.add_argument_group(
+        "BIDS FILTERS",
+        "Filters to customize PyBIDS get() as key=value pairs",
+    )
+
+    for input_type in pybids_inputs.keys():
+        argnames = (f"--filter-{input_type}", f"--filter_{input_type}")
+        arglist_default = [
+            f"{key}={value}"
+            for (key, value) in pybids_inputs[input_type]["filters"].items()
+        ]
+        arglist_default_string = " ".join(arglist_default)
+
+        filter_opts.add_argument(
+            *argnames,
+            nargs="+",
+            action=KeyValue,
+            help=f"(default: {arglist_default_string})",
+        )
+
+    # general parser for
+    # --wildcards_{input_type} {wildcard1} {wildcard2} ...
+    # create wildcards parsers, one for each input_type
+    wildcards_opts = parser.add_argument_group(
+        "INPUT WILDCARDS",
+        "File path entities to use as wildcards in snakemake",
+    )
+
+    for input_type in pybids_inputs.keys():
+        argnames = (f"--wildcards-{input_type}", f"--wildcards_{input_type}")
+        arglist_default = [f"{wc}" for wc in pybids_inputs[input_type]["wildcards"]]
+        arglist_default_string = " ".join(arglist_default)
+
+        wildcards_opts.add_argument(
+            *argnames,
+            nargs="+",
+            help=f"(default: {arglist_default_string})",
+        )
+
+    override_opts = parser.add_argument_group(
+        "PATH OVERRIDE",
+        (
+            "Options for overriding BIDS by specifying absolute paths "
+            "that include wildcards, e.g.: "
+            "/path/to/my_data/{subject}/t1.nii.gz"
+        ),
+    )
+
+    # create path override parser
+    for input_type in pybids_inputs.keys():
+        argnames = (f"--path-{input_type}", f"--path_{input_type}")
+        override_opts.add_argument(*argnames, default=None)
+
+
+def parse_snakebids_args(parser: argparse.ArgumentParser):
+    all_args = parser.parse_known_args()
+    return SnakebidsArgs(
+        snakemake_args=all_args[1],
+        # resolve all path items to get absolute paths
+        args_dict={k: _resolve_path(v) for k, v in all_args[0].__dict__.items()},
+        workflow_mode=all_args[0].workflow_mode,
+        force=all_args[0].force_conversion,
+        outputdir=Path(all_args[0].output_dir).resolve(),
+        retrofit=all_args[0].retrofit,
+    )
+
+
+def _make_underscore_dash_aliases(name: str):
+    """Generate --dash-arg aliases for --dash_args and vice versa
+
+    If no dashes or underscores are in the argument name, a tuple containing just the
+    original arg name will be returned
+
+    Parameters
+    ----------
+    name : str
+        Argument to generate conversion for
+
+    Returns
+    -------
+    tuple of strings
+        Converted args
+    """
+    match = re.match(r"^--(.+)$", name)
+    if match:
+        name_part = match.group(1)
+        return {
+            name,
+            re.sub(r"\_", "-", name),
+            f"--{re.sub(r'-', '_', name_part)}",
+        }
+    return {name}
+
+
+def _resolve_path(path_candidate: Any) -> Any:
+    """Helper function to resolve any paths or list
+    of paths it's passed. Otherwise, returns the argument
+    unchanged.
+
+    Parameters
+    ----------
+    command : list, os.Pathlike, object
+        command to run
+
+    Returns
+    -------
+    list, Path, object
+        If os.Pathlike or list  of os.Pathlike, the same paths resolved.
+        Otherwise, the argument unchanged.
+    """
+    if isinstance(path_candidate, list):
+        return [_resolve_path(p) for p in path_candidate]
+
+    if isinstance(path_candidate, os.PathLike):
+        return Path(path_candidate).resolve()
+
+    return path_candidate

--- a/snakebids/tests/mock/config.py
+++ b/snakebids/tests/mock/config.py
@@ -1,44 +1,47 @@
 # flake8: noqa
 # pylint: skip-file
-from __future__ import absolute_import
+
+pybids_inputs = {
+    "bold": {
+        "filters": {"suffix": "bold", "extension": ".nii.gz", "datatype": "func"},
+        "wildcards": ["subject", "session", "acquisition", "task", "run"],
+    }
+}
+
+parse_args = {
+    "bids_dir": {
+        "help": "The directory with the input dataset formatted according\nto the BIDS standard."
+    },
+    "output_dir": {
+        "help": "The directory where the output files\nshould be stored. If you are running group level analysis\nthis folder should be prepopulated with the results of the\nparticipant level analysis."
+    },
+    "analysis_level": {
+        "help": "Level of the analysis that will be performed.",
+        "choices": ["participant"],
+    },
+    "--participant_label": {
+        "help": 'The label(s) of the participant(s) that should be analyzed. The label\ncorresponds to sub-<participant_label> from the BIDS spec \n(so it does not include "sub-"). If this parameter is not \nprovided all subjects should be analyzed. Multiple \nparticipants can be specified with a space separated list.',
+        "nargs": "+",
+    },
+    "--exclude_participant_label": {
+        "help": 'The label(s) of the participant(s) that should be excluded. The label\ncorresponds to sub-<participant_label> from the BIDS spec \n(so it does not include "sub-"). If this parameter is not \nprovided all subjects should be analyzed. Multiple \nparticipants can be specified with a space separated list.',
+        "nargs": "+",
+    },
+    "--derivatives": {
+        "help": "Path(s) to a derivatives dataset, for folder(s) that contains multiple derivatives datasets (default: %(default)s) ",
+        "default": False,
+        "type": "Path",
+        "nargs": "+",
+    },
+    "--arg-using-dash-syntax": {
+        "help": "A fake argument for testing purposes",
+        "nargs": "+",
+    },
+}
 
 config = {
-    "pybids_inputs": {
-        "bold": {
-            "filters": {"suffix": "bold", "extension": ".nii.gz", "datatype": "func"},
-            "wildcards": ["subject", "session", "acquisition", "task", "run"],
-        }
-    },
+    "pybids_inputs": pybids_inputs,
     "targets_by_analysis_level": {"participant": [""]},
     "analysis_levels": ["participant"],
-    "parse_args": {
-        "bids_dir": {
-            "help": "The directory with the input dataset formatted according\nto the BIDS standard."
-        },
-        "output_dir": {
-            "help": "The directory where the output files\nshould be stored. If you are running group level analysis\nthis folder should be prepopulated with the results of the\nparticipant level analysis."
-        },
-        "analysis_level": {
-            "help": "Level of the analysis that will be performed.",
-            "choices": ["participant"],
-        },
-        "--participant_label": {
-            "help": 'The label(s) of the participant(s) that should be analyzed. The label\ncorresponds to sub-<participant_label> from the BIDS spec \n(so it does not include "sub-"). If this parameter is not \nprovided all subjects should be analyzed. Multiple \nparticipants can be specified with a space separated list.',
-            "nargs": "+",
-        },
-        "--exclude_participant_label": {
-            "help": 'The label(s) of the participant(s) that should be excluded. The label\ncorresponds to sub-<participant_label> from the BIDS spec \n(so it does not include "sub-"). If this parameter is not \nprovided all subjects should be analyzed. Multiple \nparticipants can be specified with a space separated list.',
-            "nargs": "+",
-        },
-        "--derivatives": {
-            "help": "Path(s) to a derivatives dataset, for folder(s) that contains multiple derivatives datasets (default: %(default)s) ",
-            "default": False,
-            "type": "Path",
-            "nargs": "+",
-        },
-        "--arg-using-dash-syntax": {
-            "help": "A fake argument for testing purposes",
-            "nargs": "+",
-        },
-    },
+    "parse_args": parse_args,
 }

--- a/snakebids/tests/test_cli.py
+++ b/snakebids/tests/test_cli.py
@@ -1,0 +1,113 @@
+# pylint: disable=protected-access, redefined-outer-name
+from __future__ import absolute_import
+
+import copy
+import sys
+from argparse import ArgumentParser
+from os import PathLike
+from pathlib import Path
+
+import pytest
+from configargparse import Namespace
+from pytest_mock.plugin import MockerFixture
+
+from snakebids.cli import (
+    _resolve_path,
+    add_dynamic_args,
+    create_parser,
+    parse_snakebids_args,
+)
+
+from .mock.config import parse_args, pybids_inputs
+
+
+@pytest.fixture
+def parser():
+    p = create_parser()
+    add_dynamic_args(p, copy.deepcopy(parse_args), copy.deepcopy(pybids_inputs))
+    return p
+
+
+class TestResolvePath:
+    @pytest.fixture
+    def arg_dict(self):
+        return {
+            "bids_dir": "path/to/input",
+            "output_dir": "path/to/output",
+            "analysis_level": "participant",
+            "--derivatives": ["path/to/deriv1", "path/to/deriv2"],
+        }
+
+    def test_does_not_change_dict_without_paths(self, arg_dict):
+        arg_dict_copy = copy.deepcopy(arg_dict)
+        resolved = {key: _resolve_path(value) for key, value in arg_dict.items()}
+        assert resolved == arg_dict_copy
+
+    def test_resolves_all_paths(self, arg_dict):
+        arg_dict["--derivatives"] = [Path("path/to/deriv1"), Path("path/to/deriv2")]
+        arg_dict_copy = copy.deepcopy(arg_dict)
+        arg_dict_copy["--derivatives"] = [
+            p.resolve() for p in arg_dict_copy["--derivatives"]
+        ]
+        resolved = {key: _resolve_path(value) for key, value in arg_dict.items()}
+        assert resolved == arg_dict_copy
+
+
+class TestAddDynamicArgs:
+    mock_args_special = ["--derivatives", "path/to/nowhere"]
+    mock_basic_args = ["script_name", "path/to/input", "path/to/output", "participant"]
+    mock_all_args = mock_basic_args + mock_args_special
+
+    def test_fails_if_missing_arguments(
+        self, parser: ArgumentParser, mocker: MockerFixture
+    ):
+        mocker.patch.object(sys, "argv", ["script_name"])
+        with pytest.raises(SystemExit):
+            parser.parse_args()
+
+    def test_succeeds_if_given_positional_args(
+        self, parser: ArgumentParser, mocker: MockerFixture
+    ):
+        mocker.patch.object(sys, "argv", self.mock_basic_args)
+        assert isinstance(parser.parse_args(), Namespace)
+
+    def test_converts_type_path_into_pathlike(
+        self, parser: ArgumentParser, mocker: MockerFixture
+    ):
+        mocker.patch.object(sys, "argv", self.mock_all_args)
+        args = parser.parse_args()
+        assert isinstance(getattr(args, "derivatives")[0], PathLike)
+
+    def test_fails_if_undefined_type_given(self):
+        parse_args_copy = copy.deepcopy(parse_args)
+        parse_args_copy["--new-param"] = {
+            "help": "Generic Help Message",
+            "type": "UnheardClass",
+        }
+        with pytest.raises(TypeError):
+            add_dynamic_args(create_parser(), parse_args_copy, pybids_inputs)
+
+    def test_resolves_paths(self, parser: ArgumentParser, mocker: MockerFixture):
+        mocker.patch.object(sys, "argv", self.mock_all_args)
+        args = parse_snakebids_args(parser).args_dict
+        assert args["derivatives"][0] == Path.cwd() / "path/to/nowhere"
+
+
+def test_dash_syntax_in_config_cli_args(parser: ArgumentParser, mocker: MockerFixture):
+    mocker.patch.object(
+        sys,
+        "argv",
+        [
+            "script_name",
+            "path/to/input",
+            "path/to/output",
+            "participant",
+            "--participant-label",
+            "12345",
+            "--arg_using_dash_syntax",
+            "7890",
+        ],
+    )
+    args = parse_snakebids_args(parser)
+    assert args.args_dict["participant_label"][0] == "12345"
+    assert args.args_dict["arg_using_dash_syntax"][0] == "7890"

--- a/snakebids/utils/output.py
+++ b/snakebids/utils/output.py
@@ -112,11 +112,11 @@ def write_output_mode(dotfile: Path, mode: Mode):
 def retrofit_output(output: Path, config_files: Iterable[Path]):
     """Convert legacy snakebids output to bidsapp mode.
 
-    Expects a directory containing previous snakebids outpus. This should contain one or
-    more config files, as specified in the config_files parameter. If a config directory
-    resides in the output, it should only contain specified config files. If extra files
-    are found, an error will be thrown. All config files will be deleted, and a new
-    .snakebids file will be created.
+    Expects a directory containing previous snakebids outputs. This should contain one
+    or more config files, as specified in the config_files parameter. If a config
+    directory resides in the output, it should only contain specified config files. If
+    extra files are found, an error will be thrown. All config files will be deleted,
+    and a new .snakebids file will be created.
 
     Parameters
     ----------


### PR DESCRIPTION
Here's my promised refactor (resolving issue #81). I moved stuff around quite a bit, so sorry if the diff is a bit hard to follow.

Basically, I separated logic concerns between the argparse CLI functionality, which is now stored in `cli.py`, and the actual `Snakebids` stuff: parsing the `snakemake_dir`, reading the config file, running the app. `SnakeBidsApp` now uses the excellent [`attrs`](https://www.attrs.org/en/stable/) library for initialization.  Most of the attributes (e.g. `configfile_path`, `snakefile_path`, `config`) are determined relative to the user provided `snakemake_dir`. Previously, these were calculated within the `__init__()` function, but now are determined using `attr.Factory`, which basically lets you use a function to set a default value for an attribute. The big advantage here is that you can override any of these attributes simply by providing a value in the class constructor, which make testing *way* easier. 

All of the argparse stuff has been packaged up into standalone functions. Again, the biggest advantage here is for testing: it's much easier to test a standalone function with a nicely defined bit of logic. The `create_parser()` function returns a parser with the basic arguments. This will allow the user to import the parser and manually tweak it [we discussed this at a previous meeting: the option of defining custom args in `run.py` rather than `config.yaml`] Alternatively, the user could initialize the `SnakeBidsApp` class and then directly update the `parser` attribute it exposes. A second function: `add_dynamic_args` takes in `config.yaml` sections as variables and updates the parser with user custom args and `--filter-xx` and `--workflow-xx` magic args. Finally, `parse_snakebids_args` performs the parsing and packages everything up into the `SnakebidsArgs` class.

Another function within `cli.py`, `update_config()`, updates the config dict with info provided by the argument parser. I wasn't sure whether or not to leave that function within `app.py`. In the end, I moved it to `cli.py` but I'm happy to change if anyone objects. Its concerns bridge those of both modules. It also modifies the `config` param it receives "in-place", which can be confusing.

As mentioned in #82, I updated the Snakemake Help function to directly call `snakemake.main()`. The `run()` function in `app.py` has been removed.

A few attributes in `SnakeBidsApp` had some issues. `skip_parse_args` was broken: if a user set it to `True`, the app would have errored out. The new modes and such require argument parsing for all the new basic arguments we added. So I disabled it's functionality and added a deprecation warning. If anyone has an idea for how it could still be useful we can definitely put it back. The other attribute: `out_configfile` wasn't in the code, just the docstring. So I just deleted it.

Other than that, I tried to flesh out documentation where applicable, including more inline comments. The tests have all been updated. I didn't add any new tests, but breaking the functions into smaller bits revealed a number of things that currently have *no* tests, especially `cli.py->update_config()`, and `cli.py->add_dynamic_args()`. These should be written up at some point.

The user facing interface should be entirely the same, other than the deprecation warning (on an attribute which was broken anyway). 