### PR TITLE
Use set() to remove duplicate arg labels

### DIFF
--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -329,7 +329,7 @@ class SnakeBidsApp:
                 )
             else:
                 names = (name,)
-            app_group.add_argument(*names, **parse_args)
+            app_group.add_argument(*set(names), **parse_args)
 
         # general parser for
         # --filter_{input_type} {key1}={value1} {key2}={value2}...


### PR DESCRIPTION
I believe #105 was a simple as using set() for de-duplication. #akhanf, could you do me a favor and test this PR? I don't have test cases prepared, and if I made them now, they'd have to immediately be changed to accomadate the refactoring in #93.

Addresses #105
