### PR TITLE
Refactor bids() function

### DIFF
--- a/snakebids/tests/test_bids.py
+++ b/snakebids/tests/test_bids.py
@@ -6,10 +6,9 @@ from .. import bids
 
 
 def test_bids_subj():
-    assert (
-        bids(root="bids", subject="001", suffix="T1w.nii.gz")
-        == "bids/sub-001/sub-001_T1w.nii.gz"
+    assert bids(root="bids", subject="001", suffix="T1w.nii.gz") == Path(
+        "bids/sub-001/sub-001_T1w.nii.gz"
     )
-    assert bids(root=Path("bids"), subject="001", suffix="T1w.nii.gz") == str(
+    assert bids(root=Path("bids").resolve(), subject="001", suffix="T1w.nii.gz") == (
         Path.cwd() / "bids/sub-001/sub-001_T1w.nii.gz"
     )


### PR DESCRIPTION
The process of working on #100 led to a lot of changes, not all of which are related. I thus thought it might be easier if I release the changes across a few PRs based on content theme. 

The main goal here was for bids() to return Paths rather than strings. Snakemake can consume Paths as input/outputs just fine, and Paths are just more convenient. 

Along the way, I refactored a few things:

- Form filename and folder in a "one-liner" list creation, rather than gradually appending items. This makes the code much more concise and clear.

- Add type annotations