### PR TITLE
Improve filter_list

### DIFF
--- a/snakebids/core/filtering.py
+++ b/snakebids/core/filtering.py
@@ -73,9 +73,9 @@ def filter_list(
         ...     },
         ...     {'subject': '01'}
         ... ) == {
-        ...     'dir': ('AP', 'PA', 'AP', 'PA'),
-        ...     'acq': ('98', '98', '99', '99'),
-        ...     'subject': ('01', '01', '01', '01')
+        ...     'dir': ['AP', 'PA', 'AP', 'PA'],
+        ...     'acq': ['98', '98', '99', '99'],
+        ...     'subject': ['01', '01', '01', '01']
         ... }
         True
 
@@ -89,9 +89,9 @@ def filter_list(
         ...     },
         ...     {'acq': '98'}
         ... ) == {
-        ...     'dir': ('AP', 'PA', 'AP', 'PA'),
-        ...     'acq': ('98', '98', '98', '98'),
-        ...     'subject': ('01', '01', '02', '02')
+        ...     'dir': ['AP', 'PA', 'AP', 'PA'],
+        ...     'acq': ['98', '98', '98', '98'],
+        ...     'subject': ['01', '01', '02', '02']
         ... }
         True
 
@@ -105,9 +105,9 @@ def filter_list(
         ...     },
         ...     {'dir': 'AP'}
         ... ) == {
-        ...     'dir': ('AP', 'AP', 'AP', 'AP'),
-        ...     'acq': ('98', '98', '99', '99'),
-        ...     'subject': ('01', '02', '01', '02')
+        ...     'dir': ['AP', 'AP', 'AP', 'AP'],
+        ...     'acq': ['98', '98', '99', '99'],
+        ...     'subject': ['01', '02', '01', '02']
         ... }
         True
 
@@ -121,9 +121,9 @@ def filter_list(
         ...     },
         ...     {'subject': '03'}
         ... ) == {
-        ...     'dir': (),
-        ...     'acq': (),
-        ...     'subject': ()
+        ...     'dir': [],
+        ...     'acq': [],
+        ...     'subject': []
         ... }
         True
     """
@@ -137,11 +137,11 @@ def filter_list(
         # zip_list
         {*range(len(zip_list[next(iter(zip_list))]))},
         *(
-            (
+            {
                 i
                 for i, v in enumerate(zip_list[key])
                 if matches_any(v, itx.always_iterable(val), match_func)
-            )
+            }
             for key, val in filters.items()
             if key in zip_list
         )

--- a/snakebids/core/filtering.py
+++ b/snakebids/core/filtering.py
@@ -12,7 +12,7 @@ from snakebids.utils.utils import matches_any
 @overload
 def filter_list(
     zip_list,
-    filters: Dict[str, Union[str, List[str]]],
+    filters: Union[Dict[str, str], Dict[str, List[str]]],
     return_indices_only: Literal[False] = ...,
     regex_search: bool = ...,
 ) -> Dict[str, Tuple[str]]:
@@ -22,7 +22,7 @@ def filter_list(
 @overload
 def filter_list(
     zip_list,
-    filters: Dict[str, Union[str, List[str]]],
+    filters: Union[Dict[str, str], Dict[str, List[str]]],
     return_indices_only: Literal[True] = ...,
     regex_search: bool = ...,
 ) -> Tuple[int]:
@@ -31,7 +31,7 @@ def filter_list(
 
 def filter_list(
     zip_list: Dict[str, List[str]],
-    filters: Dict[str, Union[str, List[str]]],
+    filters: Union[Dict[str, str], Dict[str, List[str]]],
     return_indices_only=False,
     regex_search=False,
 ):

--- a/snakebids/core/filtering.py
+++ b/snakebids/core/filtering.py
@@ -135,7 +135,7 @@ def filter_list(
     keep_indices = set.intersection(
         # Get a set {0,1,2,3...n-1} where n is the length of any one of the lists in
         # zip_list
-        {*range(len(zip_list[next(iter(zip_list))]))},
+        {*_get_zip_list_indices(zip_list)},
         *(
             {
                 i
@@ -248,3 +248,42 @@ def get_filtered_ziplist_index(zip_list, wildcards, subj_wildcards):
     if len(indices) == 1:
         return indices[0]
     return indices
+
+
+def _get_zip_list_indices(zip_list: Dict[str, List[str]]):
+    """Convert a zip_list into its indices
+
+    Generates a sequence of numbers from 0 up to the length of the zip_lists. For
+    example, the zip list:
+
+    zip_list = {
+        "subject": ["001", "002", "001", "002"],
+        "contrast": ["T1w", "T1w", "T2w", "T2w"]
+    }
+
+    would lead to:
+
+    (0, 1, 2, 3)
+
+    Parameters
+    ----------
+    zip_list : Dict[str, List[str]]
+        Zip_list to be converted
+
+    Yields
+    -------
+    integers
+        The indices of the zip_list
+    """
+
+    if not zip_list:
+        return
+
+    # Retrieve the first zip_list (all zip_lists should be the same, so it doesn't
+    # matter which one we take)
+    # pylint: disable=stop-iteration-return
+    sample_zip_list = zip_list[next(iter(zip_list))]
+
+    # Return a sequence of numbers 0, 1, 2, 3, ... n-1 where n is the length of the
+    # zip list
+    yield from range(len(sample_zip_list))

--- a/snakebids/core/filtering.py
+++ b/snakebids/core/filtering.py
@@ -1,17 +1,20 @@
 import operator as op
 import re
-from typing import Dict, List, Union, overload
+from typing import Dict, List, TypeVar, Union, overload
 
 import more_itertools as itx
 from typing_extensions import Literal
 
 from snakebids.utils.utils import matches_any
 
+# pylint: disable=invalid-name
+T_cov = TypeVar("T_cov", bound=Union[List[str], str], covariant=True)
+
 
 @overload
 def filter_list(
     zip_list,
-    filters: Union[Dict[str, str], Dict[str, List[str]]],
+    filters: Dict[str, T_cov],
     return_indices_only: Literal[False] = ...,
     regex_search: bool = ...,
 ) -> Dict[str, List[str]]:
@@ -21,7 +24,7 @@ def filter_list(
 @overload
 def filter_list(
     zip_list,
-    filters: Union[Dict[str, str], Dict[str, List[str]]],
+    filters: Dict[str, T_cov],
     return_indices_only: Literal[True] = ...,
     regex_search: bool = ...,
 ) -> List[int]:
@@ -30,7 +33,7 @@ def filter_list(
 
 def filter_list(
     zip_list: Dict[str, List[str]],
-    filters: Union[Dict[str, str], Dict[str, List[str]]],
+    filters: Dict[str, T_cov],
     return_indices_only=False,
     regex_search=False,
 ):

--- a/snakebids/core/input_generation.py
+++ b/snakebids/core/input_generation.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import re
+from typing import Dict, List, Tuple
 
 from bids import BIDSLayout, BIDSLayoutIndexer
 
@@ -303,9 +304,10 @@ def _process_path_override(input_path):
     if len(wildcard_names) == 0:
         _logger.warning("No wildcards defined in %s", input_path)
 
-    input_wildcards = {}
-    input_zip_lists = {}
-    input_lists = {}
+    # Initialize output values
+    input_wildcards: Dict[str, str] = {}
+    input_zip_lists: Dict[str, Tuple[str]] = {}
+    input_lists: Dict[str, List[str]] = {}
 
     for i, wildcard in enumerate(wildcard_names):
         input_zip_lists[wildcard] = wildcards[i]

--- a/snakebids/tests/test_filtering.py
+++ b/snakebids/tests/test_filtering.py
@@ -16,9 +16,9 @@ from snakebids.core.filtering import filter_list
             },
             {"subject": "01"},
             {
-                "dir": ("AP", "PA", "AP", "PA"),
-                "acq": ("98", "98", "99", "99"),
-                "subject": ("01", "01", "01", "01"),
+                "dir": ["AP", "PA", "AP", "PA"],
+                "acq": ["98", "98", "99", "99"],
+                "subject": ["01", "01", "01", "01"],
             },
         ),
         (
@@ -29,9 +29,9 @@ from snakebids.core.filtering import filter_list
             },
             {"acq": "98"},
             {
-                "dir": ("AP", "PA", "AP", "PA"),
-                "acq": ("98", "98", "98", "98"),
-                "subject": ("01", "01", "02", "02"),
+                "dir": ["AP", "PA", "AP", "PA"],
+                "acq": ["98", "98", "98", "98"],
+                "subject": ["01", "01", "02", "02"],
             },
         ),
         (
@@ -42,9 +42,9 @@ from snakebids.core.filtering import filter_list
             },
             {"dir": "AP"},
             {
-                "dir": ("AP", "AP", "AP", "AP"),
-                "acq": ("98", "98", "99", "99"),
-                "subject": ("01", "02", "01", "02"),
+                "dir": ["AP", "AP", "AP", "AP"],
+                "acq": ["98", "98", "99", "99"],
+                "subject": ["01", "02", "01", "02"],
             },
         ),
         (
@@ -53,8 +53,8 @@ from snakebids.core.filtering import filter_list
                 "acq": ["98", "98", "98", "98", "99", "99", "99", "99"],
                 "subject": ["01", "01", "02", "02", "01", "01", "02", "02"],
             },
-            {"subject": "03"},
-            {"dir": (), "acq": (), "subject": ()},
+            {"subject": "03", "dir": "AP"},
+            {"dir": [], "acq": [], "subject": []},
         ),
         (
             {
@@ -63,15 +63,15 @@ from snakebids.core.filtering import filter_list
             },
             {"subject": ["01", "03"]},
             {
-                "dir": ("AP", "PA", "AP", "PA"),
-                "subject": ("01", "01", "03", "03"),
+                "dir": ["AP", "PA", "AP", "PA"],
+                "subject": ["01", "01", "03", "03"],
             },
         ),
     ],
 )
 def test_filter_list(
     zip_list: Dict[str, Dict[str, List[str]]],
-    filters: Dict[str, Union[str, List[str]]],
+    filters: Union[Dict[str, str], Dict[str, List[str]]],
     output: Dict[str, Dict[str, List[str]]],
 ):
     assert filter_list(zip_list, filters) == output

--- a/snakebids/tests/test_filtering.py
+++ b/snakebids/tests/test_filtering.py
@@ -1,0 +1,77 @@
+from typing import Dict, List, Union
+
+import pytest
+
+from snakebids.core.filtering import filter_list
+
+
+@pytest.mark.parametrize(
+    ("zip_list", "filters", "output"),
+    [
+        (
+            {
+                "dir": ["AP", "PA", "AP", "PA", "AP", "PA", "AP", "PA"],
+                "acq": ["98", "98", "98", "98", "99", "99", "99", "99"],
+                "subject": ["01", "01", "02", "02", "01", "01", "02", "02"],
+            },
+            {"subject": "01"},
+            {
+                "dir": ("AP", "PA", "AP", "PA"),
+                "acq": ("98", "98", "99", "99"),
+                "subject": ("01", "01", "01", "01"),
+            },
+        ),
+        (
+            {
+                "dir": ["AP", "PA", "AP", "PA", "AP", "PA", "AP", "PA"],
+                "acq": ["98", "98", "98", "98", "99", "99", "99", "99"],
+                "subject": ["01", "01", "02", "02", "01", "01", "02", "02"],
+            },
+            {"acq": "98"},
+            {
+                "dir": ("AP", "PA", "AP", "PA"),
+                "acq": ("98", "98", "98", "98"),
+                "subject": ("01", "01", "02", "02"),
+            },
+        ),
+        (
+            {
+                "dir": ["AP", "PA", "AP", "PA", "AP", "PA", "AP", "PA"],
+                "acq": ["98", "98", "98", "98", "99", "99", "99", "99"],
+                "subject": ["01", "01", "02", "02", "01", "01", "02", "02"],
+            },
+            {"dir": "AP"},
+            {
+                "dir": ("AP", "AP", "AP", "AP"),
+                "acq": ("98", "98", "99", "99"),
+                "subject": ("01", "02", "01", "02"),
+            },
+        ),
+        (
+            {
+                "dir": ["AP", "PA", "AP", "PA", "AP", "PA", "AP", "PA"],
+                "acq": ["98", "98", "98", "98", "99", "99", "99", "99"],
+                "subject": ["01", "01", "02", "02", "01", "01", "02", "02"],
+            },
+            {"subject": "03"},
+            {"dir": (), "acq": (), "subject": ()},
+        ),
+        (
+            {
+                "dir": ["AP", "PA", "AP", "PA", "AP", "PA", "AP", "PA"],
+                "subject": ["01", "01", "02", "02", "03", "03", "04", "04"],
+            },
+            {"subject": ["01", "03"]},
+            {
+                "dir": ("AP", "PA", "AP", "PA"),
+                "subject": ("01", "01", "03", "03"),
+            },
+        ),
+    ],
+)
+def test_filter_list(
+    zip_list: Dict[str, Dict[str, List[str]]],
+    filters: Dict[str, Union[str, List[str]]],
+    output: Dict[str, Dict[str, List[str]]],
+):
+    assert filter_list(zip_list, filters) == output

--- a/snakebids/tests/test_filtering.py
+++ b/snakebids/tests/test_filtering.py
@@ -67,6 +67,20 @@ from snakebids.core.filtering import filter_list
                 "subject": ["01", "01", "03", "03"],
             },
         ),
+        (
+            {
+                "dir": ["AP", "PA", "AP", "PA", "AP", "PA", "AP", "PA"],
+                "subject": ["01", "01", "02", "02", "03", "03", "04", "04"],
+            },
+            {"subject": ["01", "02"], "dir": "AP"},
+            {
+                "dir": [
+                    "AP",
+                    "AP",
+                ],
+                "subject": ["01", "02"],
+            },
+        ),
     ],
 )
 def test_filter_list(

--- a/snakebids/tests/test_filtering.py
+++ b/snakebids/tests/test_filtering.py
@@ -85,7 +85,7 @@ from snakebids.core.filtering import filter_list
 )
 def test_filter_list(
     zip_list: Dict[str, Dict[str, List[str]]],
-    filters: Union[Dict[str, str], Dict[str, List[str]]],
+    filters: Dict[str, Union[List[str], str]],
     output: Dict[str, Dict[str, List[str]]],
 ):
     assert filter_list(zip_list, filters) == output

--- a/snakebids/tests/test_utils.py
+++ b/snakebids/tests/test_utils.py
@@ -1,0 +1,59 @@
+import operator as op
+import re
+from typing import List, Tuple
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from snakebids.utils.utils import matches_any
+
+
+@given(st.text(), st.lists(st.text()))
+def test_matches_any_with_eq_operator(item: str, match_list: List[str]):
+    if item not in match_list:
+        assert matches_any(item, match_list, op.eq) is False
+        match_list.append(item)
+    assert matches_any(item, match_list, op.eq)
+
+
+@st.composite
+def NonMatchingMatchList(draw: st.DrawFn):
+    item = draw(st.text())
+    match_list = draw(
+        st.lists(
+            st.text(
+                # blank match strings (e.g. ['']) will match anything, and are not
+                # considered here
+                min_size=1
+            )
+            .map(re.escape)
+            .filter(lambda s: not re.match(s, item))
+        )
+    )
+    return item, match_list
+
+
+@given(NonMatchingMatchList())
+def test_matches_any_with_re_match(args: Tuple[str, List[str]]):
+    item, match_list = args
+
+    if item not in match_list:
+        assert matches_any(item, match_list, re.match) is False
+        match_list.append(re.escape(item))
+    assert matches_any(item, match_list, re.match)
+
+
+@given(st.emails())
+def test_matches_any_with_email(email: str):
+    match_list = ["non[^@]*?email[pattern]"]
+    assert matches_any(email, match_list, re.match) is False
+    # Email regex copied from https://www.emailregex.com/
+    match_list.append(
+        r'(?:[a-z0-9!#$%&\'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&\'*+/=?^_`{|}~-]+)*|"(?:['
+        r"\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-"
+        r'\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*'
+        r"[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2"
+        r"[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-"
+        r"\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])"
+    )
+    assert matches_any(email, match_list, re.match, re.IGNORECASE)

--- a/snakebids/utils/utils.py
+++ b/snakebids/utils/utils.py
@@ -1,7 +1,7 @@
 import functools as ft
 import importlib.resources
 import json
-from typing import Dict
+from typing import Any, Callable, Dict, List
 
 
 @ft.lru_cache(None)
@@ -28,3 +28,36 @@ def read_bids_tags(bids_json=None) -> Dict[str, str]:
     with importlib.resources.open_text("snakebids.resources", "bids_tags.json") as file:
         bids_tags = json.load(file)
     return bids_tags
+
+
+def matches_any(
+    item: Any, match_list: List[Any], match_func: Callable[[Any, Any], Any], *args: Any
+):
+    for match in match_list:
+        if match_func(match, item, *args):
+            return True
+    return False
+
+
+def get_match_search_func(match_list: List[Any], match_func: Callable[[Any, Any], Any]):
+    """Return a match search function suitable for use in filter
+
+    Parameters
+    ----------
+    match_list : list
+        list of items to search for matches
+    match_func : callable
+        Any callable that takes two args and returns truthy/falsy values. The first arg
+        will be drawn from match_list, the second will be the value being matched
+
+    Returns
+    -------
+    callable
+        Takes as a single arg a value to be matched. It will be compared to every item
+        in match list using match_func
+    """
+
+    def inner(item: Any):
+        return matches_any(item, match_list, match_func)
+
+    return inner

--- a/snakebids/utils/utils.py
+++ b/snakebids/utils/utils.py
@@ -1,7 +1,7 @@
 import functools as ft
 import importlib.resources
 import json
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, Iterable, List
 
 
 @ft.lru_cache(None)
@@ -31,7 +31,10 @@ def read_bids_tags(bids_json=None) -> Dict[str, str]:
 
 
 def matches_any(
-    item: Any, match_list: List[Any], match_func: Callable[[Any, Any], Any], *args: Any
+    item: Any,
+    match_list: Iterable[Any],
+    match_func: Callable[[Any, Any], Any],
+    *args: Any
 ):
     for match in match_list:
         if match_func(match, item, *args):


### PR DESCRIPTION
The zip list filter previously could only filter one entity-value at a time. In other words, you could search for a single subject, a single aquisition, etc, but not subjects 4 and 5 in the AP direction. This PR updates it to support any arbitrary combination of entities. It also supports regex_search, using the same interface as `pybids.get()`. A formal test was created by copying out the doc string (which admittedly doesn't add much but it's easier for me to run the test in VS-code that way). I added a new condition to the formal test to test searching by entity combinations.

Due to my use of `zip()` within `filter_list`, each `zip_list` is now returned as a tuple instead of a list. I didn't feel the need to correct this: realistically the user should not be `append()`ing anything to the `zip_lists`, and if they really want to, they can convert to a list themselves. I have not yet gone through and changed every function creating a `zip_list` so that they all make tuples instead, but this will be done an upcoming PR (fairly soon...). In the meantime, tuples and lists are similar enough that I don't think it will make a difference.