### PR TITLE
Bids returns str instead of Path

### DIFF
--- a/snakebids/core/bids.py
+++ b/snakebids/core/bids.py
@@ -194,7 +194,7 @@ def bids(
         )
     )
 
-    return folder / filename
+    return str(folder / filename)
 
 
 def print_boilerplate():

--- a/snakebids/tests/test_bids.py
+++ b/snakebids/tests/test_bids.py
@@ -6,9 +6,9 @@ from snakebids.core.bids import bids
 
 
 def test_bids_subj():
-    assert bids(root="bids", subject="001", suffix="T1w.nii.gz") == Path(
+    assert bids(root="bids", subject="001", suffix="T1w.nii.gz") == (
         "bids/sub-001/sub-001_T1w.nii.gz"
     )
     assert bids(root=Path("bids").resolve(), subject="001", suffix="T1w.nii.gz") == (
-        Path.cwd() / "bids/sub-001/sub-001_T1w.nii.gz"
+        str(Path.cwd() / "bids/sub-001/sub-001_T1w.nii.gz")
     )


### PR DESCRIPTION
Hotfix for #119

Returning a Path was causing all sorts of unpredictable errors within Snakemake workflows, apparently due to lack of full Path compatibility in Snakemake
