### PR TITLE
Auto-assign reviewers

### DIFF
--- a/.github/auto-assign.yml
+++ b/.github/auto-assign.yml
@@ -1,0 +1,29 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: author
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - akhanf
+  - tkkuehn
+  - kaitj
+  - pvandyken
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 2
+
+# A list of assignees, overrides reviewers if set
+# assignees:
+#   - assigneeA
+
+# A number of assignees to add to the pull request
+# Set to 0 to add all of the assignees.
+# Uses numberOfReviewers if unset.
+# numberOfAssignees: 2
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it
+# skipKeywords:
+#   - wip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,3 +112,16 @@ jobs:
     - name: Test with pytest
       run: |
         poetry run pytest --doctest-modules --ignore=docs --ignore=snakebids/project_template
+
+
+  assign:
+    runs-on: ubuntu-latest
+    name: Reviewer assignment
+    needs: [test]
+    if: github.event.pull_request.assignee == null
+
+    steps:
+      - name: Assign reviewer
+        uses: kentaro-m/auto-assign-action@v1.1.2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Just copied this over from the `afids-validator`. This PR just automatically assigns reviewers if the tests pass in github actions. 

Currently, it will assign 3 reviewers and an assignee (author of PR). Can change the list of reviewers by editing the `auto-assign.yml` file. Does not change the code, just skips the added step of having to manually add reviewers after submitting a PR.