### PR TITLE
Make `poe test` run full test suite (as in gh-actions)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poe.tasks]
 setup = "pre-commit install"
 quality = { shell = "isort snakebids && black snakebids && flake8 snakebids && pylint snakebids" }
-test = "pytest"
+test = "pytest --doctest-modules --ignore=docs --ignore=project_template"
 mkinit = "mkinit --recursive --nomods --black -i snakebids"
 
 [tool.isort]


### PR DESCRIPTION
A small one here: this updates the `test` command in `poe` to run the entire pytest command as in gh-actions, especially including the `doctest-modules`.
