### PR TITLE
Update workflows for branch protection

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,13 +1,16 @@
 name: Bump version
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types: [closed]
 jobs:
   build:
+    if: github.event.pull_request.merged == true 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout master branch
+        uses: actions/checkout@v2
+        with:
+          ref: refs/heads/main
       
       - name: Update changelog
         uses: release-drafter/release-drafter@v5
@@ -60,8 +63,8 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git diff-index --quiet HEAD || git commit -m "Bump version to $SNAKEBIDS_VERSION" -a
 
-      - name: Push changes
-        uses: ad-m/github-push-action@master
+      - name: Push changes 
+        uses: CasperWA/push-protected@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tags: false
+          token: ${{ secrets.BP_PAT_TOKEN }}
+          unprotect_reviews: True 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,10 +60,11 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git diff-index --quiet HEAD || git commit -m "Bump version to $LATEST_VERSION" -a
 
-      - name: Push changes
-        uses: ad-m/github-push-action@master
+      - name: Push changes 
+        uses: CasperWA/push-protected@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BP_PAT_TOKEN }}
+          unprotect_reviews: True 
 
       - name: Publish change log
         uses: release-drafter/release-drafter@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,13 @@ name: Test workflow
 
 on:
   push:
+    branches:
+      - '*'
+      - '!push-action/*'
   pull_request:
+    branches:
+      - '*'
+      - '!push-action/*'
 
 jobs:
   quality:


### PR DESCRIPTION
This PR updates the workflows so protected branches can be used: 
- Switches push action to use `CasperWA/push-protected@v2` with PAT token
- Changes `bump_version.yml` trigger from `push` to `pull_request`. Only runs if this is triggered due a merged PR. Functionally the same as before.
- Added specific branches to `test.yml` to disable duplicate testing triggered by protected push.
  - Runs on all branches except those that start with `push-action/`, which is a branch created by the `CasperWA/push-protect` action.

@akhanf This should allow for branch protections to be re-enabled! Will need to generate a personal access token (saved as `BP_PAT_TOKEN` in the repository secrets) with repo access for the `push-protect` to work. 