### PR TITLE
Add templates for issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,16 @@
+## The problem
+
+Briefly describe the issue you are experiencing (or feature you want to see added).
+
+## Error
+
+Did you receive an error? If you did, include it here!
+
+## Screenshots
+
+If you have any helpful screenshots or a file you tried to upload, please include them!
+
+## Environment
+
+* `snakebids` version (if applicable)
+* Operating system (e.g. Ubuntu 20.04, Windows 10)

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,10 +1,11 @@
 ## The problem
 
-Briefly describe the issue you are experiencing (or feature you want to see added).
+Briefly describe the issue you are experiencing (or feature you want to see added). If you received an error,
+please include the error message!
 
-## Error
+## Steps to reproduce
 
-Did you receive an error? If you did, include it here!
+Please also include the steps you took so we can try to reproduce the error!
 
 ## Screenshots
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Proposed changes
+
+Describe the changes implemented in this pull request. If the changes fix a bug or resolves a feature request, be sure to link the issue (and explain how the changes address the issue). Be sure to select a label describing the PR (e.g. maintenance).
+
+## Checklist
+
+Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!
+
+- [ ] Changes have been tested to ensure that fix is effective or that a feature works.
+- [ ] Changes pass the unit tests
+- [ ] I have included necessary documentation or comments (as necessary)
+- [ ] Any dependent changes have been merged and published
+
+## Notes
+All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.


### PR DESCRIPTION
This PR just adds some default templates to collect information from users when trying to make a PR / issue. Feel free to suggest any changes or inclusions to the template.