### PR TITLE
Fix auto-assign

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,0 +1,14 @@
+name: Assign reviewer 
+
+on:
+  pull_request_target: 
+
+jobs: 
+  assign:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Assign reviewer
+        uses: kentaro-m/auto-assign-action@v1.1.2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}" 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Reviewer assignment
     needs: [test]
-    if: github.event_name == 'pull_request' && github.event.pull_request.assignee == null
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.assignee == null
 
     steps:
       - name: Assign reviewer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,16 +112,3 @@ jobs:
     - name: Test with pytest
       run: |
         poetry run pytest --doctest-modules --ignore=docs --ignore=snakebids/project_template
-
-
-  assign:
-    runs-on: ubuntu-latest
-    name: Reviewer assignment
-    needs: [test]
-    if: github.event_name == 'pull_request' && github.event.pull_request.assignee == null
-
-    steps:
-      - name: Assign reviewer
-        uses: kentaro-m/auto-assign-action@v1.1.2
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ name: Test workflow
 
 on:
   push:
-  pull_request_target:
+  pull_request:
 
 jobs:
   quality:
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Reviewer assignment
     needs: [test]
-    if: github.event_name == 'pull_request_target' && github.event.pull_request.assignee == null
+    if: github.event_name == 'pull_request' && github.event.pull_request.assignee == null
 
     steps:
       - name: Assign reviewer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ name: Test workflow
 
 on:
   push:
-  pull_request:
+  pull_request_target:
 
 jobs:
   quality:


### PR DESCRIPTION
Resolves #131. 

Actions that require write permissions to the repo (e.g. committing and pushing during the action) or repo secrets (e.g. the use of `secrets.GITHUB_TOKEN`) does not work on forks. When `pull_request` is the trigger, the workflow only has **read access** and **if user (without write access)** authored a PR from a fork, any workflows requiring repository secrets or write access will fail. The workaround is to use `pull_request_target`, which functionally is the same as `pull_request`, but also enables **all** users to have **write access** and access to repository secrets through the workflow. 

The changes from this PR:
* Splits up reviewer assignment from test workflow for security purposes
  * `pull_request_target` has some security vulnerabilities when paired with the `actions/checkout` using default parameters. To get around this, i moved the reviewer assignment to its own workflow that does not require the commit to be checked out and paired with `pull_request_target`, keeping the test workflow the same. This does mean all PRs will be assigned to reviewers prior to the completion of unit testing.

_Here's a long [video](https://www.youtube.com/watch?v=Ww5gjAm-2GY&t=1946s) that goes into a bit of detail about github actions and pull requests._