### PR TITLE
Add ability to use pybids db

### DIFF
--- a/docs/bids_app/config.rst
+++ b/docs/bids_app/config.rst
@@ -22,6 +22,8 @@ In the following (YAML-formatted) example, the ``bold`` input type is specified.
         - task
         - run
 
+pybids_db: A dictionary that provides a path to save the ``PyBIDS`` layout and whether the layout should be updated. The layout path is defined by ``database_dir``. If a layout should be saved / used, this value can be set to ``''``. If a ``database_dir`` is provided and the layout should be updated, set ``reset_database`` to ``True``. Default behaviour is to use the existing database provided.
+
 analysis_levels: A list of analysis levels in the BIDS app. Typically, this will include participant and/or group. Note that the default (YAML) configuration file expects this mapping to be identified with the anchor ``analysis_levels`` to be aliased by ``parse_args``.
 
 targets_by_analysis_level: A mapping from the name of each ``analysis_level`` to the list of rules or files to be run for that analysis level.
@@ -31,4 +33,3 @@ parse_args: A dictionary of command-line parameters to make available as part of
 debug: A boolean that determines whether debug statements are printed during parsing. Should be disabled (False) if you're generating DAG visualization with snakemake.
 
 derivatives: A boolean (or path(s) to derivatives datasets) that determines whether snakebids will search in the derivatives subdirectory of the input dataset.
-

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -186,6 +186,12 @@ class SnakeBidsApp:
         # - Set mode (bidsapp or workflow) and output_dir appropriately
         self.config["snakemake_dir"] = self.snakemake_dir
         self.config["snakefile"] = self.snakefile_path
+
+        # Update config with pybids settings
+        if args.pybidsdb_dir:
+            self.config["pybids_db_dir"] = args.pybidsdb_dir
+        self.config["pybids_db_reset"] = args.reset_db
+
         update_config(self.config, args)
         if mode == "workflow":
             self.config["output_dir"] = str(root)

--- a/snakebids/cli.py
+++ b/snakebids/cli.py
@@ -53,6 +53,8 @@ class SnakebidsArgs:
         data loss
     outputdir : Path
         Directory to place outputs
+    pybidsdb_dir : Path
+        Directory to place pybids database
     retrofit : Path
         Convert a legacy snakebids app to the new style
     snakemake_args : list of strings
@@ -69,6 +71,8 @@ class SnakebidsArgs:
     retrofit: bool
     snakemake_args: List[str]
     args_dict: Dict[str, Any]
+    pybidsdb_dir: Path = None
+    reset_db: bool = False
 
 
 def create_parser(include_snakemake=False):
@@ -122,6 +126,24 @@ def create_parser(include_snakemake=False):
             "Force snakebids to convert a workflow output to a bidsapp output. "
             "conversion will delete all the files in the workflow snakebids app."
         ),
+    )
+
+    standard_group.add_argument(
+        "--pybidsdb-dir",
+        "--pybidsdb_dir",
+        action="store",
+        help=(
+            "Optional path to directory of SQLite databasefile for PyBIDS. "
+            "If directory is passed and folder exists, indexing is skipped. "
+            "If reset_db is called, indexing will persist"
+        ),
+    )
+
+    standard_group.add_argument(
+        "--reset-db",
+        "--reset_db",
+        action="store_true",
+        help=("Reindex existing PyBIDS SQLite database"),
     )
 
     standard_group.add_argument(
@@ -239,6 +261,12 @@ def parse_snakebids_args(parser: argparse.ArgumentParser):
         workflow_mode=all_args[0].workflow_mode,
         force=all_args[0].force_conversion,
         outputdir=Path(all_args[0].output_dir).resolve(),
+        pybidsdb_dir=(
+            None
+            if all_args[0].pybidsdb_dir is None
+            else Path(all_args[0].pybidsdb_dir).resolve()
+        ),
+        reset_db=all_args[0].reset_db,
         retrofit=all_args[0].retrofit,
     )
 

--- a/snakebids/project_template/{{cookiecutter.app_name}}/config/snakebids.yml
+++ b/snakebids/project_template/{{cookiecutter.app_name}}/config/snakebids.yml
@@ -6,10 +6,10 @@ debug: False
 
 derivatives: False #will search in bids/derivatives if True; can also be path(s) to derivatives datasets
 
-#list of analysis levels in the bids app 
+#list of analysis levels in the bids app
 analysis_levels: &analysis_levels
  - participant
-  
+
 
 #mapping from analysis_level to set of target rules or files
 targets_by_analysis_level:
@@ -33,41 +33,46 @@ pybids_inputs:
       - acquisition
       - task
       - run
-   
+
+#this configures the options to save the BIDSLayout
+# by default, database is not saved (uncomment to save)
+# NOTE: pybids_db_dir must be an absolute path
+# pybids_db_dir: '/path/to/db_dir' # Leave blank if you do not wish to use this
+# pybids_db_reset: False # Change this to true to update the database
 
 #configuration for the command-line parameters to make available
 # passed on the argparse add_argument()
 parse_args:
 
-#---  core BIDS-app options --- (do not modify below) 
+#---  core BIDS-app options --- (do not modify below)
 
   bids_dir:
-    help: The directory with the input dataset formatted according 
+    help: The directory with the input dataset formatted according
           to the BIDS standard.
 
   output_dir:
-    help: The directory where the output files 
+    help: The directory where the output files
           should be stored. If you are running group level analysis
           this folder should be prepopulated with the results of the
           participant level analysis.
 
-  analysis_level: 
-    help: Level of the analysis that will be performed. 
+  analysis_level:
+    help: Level of the analysis that will be performed.
     choices: *analysis_levels
 
   --participant_label:
-    help: The label(s) of the participant(s) that should be analyzed. The label 
-          corresponds to sub-<participant_label> from the BIDS spec 
-          (so it does not include "sub-"). If this parameter is not 
-          provided all subjects should be analyzed. Multiple 
+    help: The label(s) of the participant(s) that should be analyzed. The label
+          corresponds to sub-<participant_label> from the BIDS spec
+          (so it does not include "sub-"). If this parameter is not
+          provided all subjects should be analyzed. Multiple
           participants can be specified with a space separated list.
     nargs: '+'
 
   --exclude_participant_label:
-    help: The label(s) of the participant(s) that should be excluded. The label 
-          corresponds to sub-<participant_label> from the BIDS spec 
-          (so it does not include "sub-"). If this parameter is not 
-          provided all subjects should be analyzed. Multiple 
+    help: The label(s) of the participant(s) that should be excluded. The label
+          corresponds to sub-<participant_label> from the BIDS spec
+          (so it does not include "sub-"). If this parameter is not
+          provided all subjects should be analyzed. Multiple
           participants can be specified with a space separated list.
     nargs: '+'
 
@@ -89,7 +94,3 @@ parse_args:
 #singularity containers
 singularity:
     fsl: 'docker://brainlife/fsl/6.0.0'
-
-
-
-

--- a/snakebids/project_template/{{cookiecutter.app_name}}/workflow/Snakefile
+++ b/snakebids/project_template/{{cookiecutter.app_name}}/workflow/Snakefile
@@ -10,6 +10,8 @@ config.update(
     snakebids.generate_inputs(
         bids_dir=config["bids_dir"],
         pybids_inputs=config["pybids_inputs"],
+        pybids_database_dir=config.get("pybids_db_dir"),
+        pybids_reset_database=config.get("pybids_db_reset"),
         derivatives=config["derivatives"],
         participant_label=config["participant_label"],
         exclude_participant_label=config["exclude_participant_label"]

--- a/snakebids/tests/mock/config.yaml
+++ b/snakebids/tests/mock/config.yaml
@@ -19,6 +19,8 @@ pybids_inputs:
       - task
       - run
 
+pybids_db_dir: '/path/to/db_dir'
+pybids_db_reset: False
 
 targets_by_analysis_level:
   participant:

--- a/snakebids/tests/test_app.py
+++ b/snakebids/tests/test_app.py
@@ -29,6 +29,7 @@ def app(mocker: MockerFixture):
     )
     app.config["analysis_level"] = "participant"
     app.config["snakemake_args"] = []
+    app.config["pybids_db_reset"] = False
     mocker.patch.object(sn_app, "update_config", return_value=app.config)
     return app
 
@@ -55,6 +56,8 @@ class TestRunSnakemake:
         expected_config["root"] = "results"
         expected_config["snakemake_dir"] = Path("app").resolve()
         expected_config["snakefile"] = Path("Snakefile")
+        expected_config["pybids_db_dir"] = Path("/tmp/output/.db")
+        expected_config["pybids_db_reset"] = True
 
         io_mocks["prepare_output"].return_value = Path("/tmp/output/results")
 
@@ -62,6 +65,8 @@ class TestRunSnakemake:
             workflow_mode=True,
             force=False,
             outputdir=Path("/tmp/output"),
+            pybidsdb_dir=Path("/tmp/output/.db"),
+            reset_db=True,
             retrofit=False,
             snakemake_args=[],
             args_dict={},
@@ -100,13 +105,16 @@ class TestRunSnakemake:
         expected_config["root"] = ""
         expected_config["snakemake_dir"] = Path("app").resolve()
         expected_config["snakefile"] = Path("Snakefile")
+        expected_config["pybids_db_dir"] = Path("/tmp/output/.db")
+        expected_config["pybids_db_reset"] = True
 
         io_mocks["prepare_output"].return_value = Path("/tmp/output")
-
         app.args = SnakebidsArgs(
             workflow_mode=False,
             force=False,
             outputdir=Path("/tmp/output"),
+            pybidsdb_dir=Path("/tmp/output/.db"),
+            reset_db=True,
             retrofit=False,
             snakemake_args=[],
             args_dict={},


### PR DESCRIPTION
This PR adds in functionality to save the `pybids` db. 

It adds a `pybids_db` to the config, where it stores the db directory, and a flag as to whether the db should be overwritten. Wanted this to be separate from the `pybids_inputs`. This also updates the `generate_input.py` to make use of these config options. If the directory is left blank (e.g. `''`), the database will be set to `None` (if left as `''`, it saves the db in the current working directory). Also added in a few small test cases to make sure the db is working as expected.

~@pvandyken I didn't end up using the `pytest.fixtures` and `tmpdir` (mentioned last week) to create the new temporary data during testing - looked as if these temp files would be created at the beginning of the test which would have been picked up by `pybids` and wanted to test for changes.~