### PR TITLE
Zenodo badge

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,8 @@
 name-template: '$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
+#header: |
+#[![DOI](https://zenodo.org/badge/309495236.svg)](https://zenodo.org/badge/latestdoi/309495236)
+
 template: |
   ## Changes
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 
 snakebids
 =========
+[![Tests](https://github.com/akhanf/snakebids/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/akhanf/snakebids/actions/workflows/test.yml?query=branch%3Amain)
 [![Documentation Status](https://readthedocs.org/projects/snakebids/badge/?version=latest)](https://snakebids.readthedocs.io/en/latest/?badge=latest)
+[![Version](https://img.shields.io/github/v/tag/akhanf/snakebids?label=version)](https://pypi.org/project/snakebids/)
+[![Python versions](https://img.shields.io/pypi/pyversions/snakebids)](https://pypi.org/project/snakebids/)
 [![DOI](https://zenodo.org/badge/309495236.svg)](https://zenodo.org/badge/latestdoi/309495236)
 
 Snakemake + BIDS
-
 This package allows you to build BIDS Apps using Snakemake. It offers:
 
 
@@ -18,7 +20,7 @@ This package allows you to build BIDS Apps using Snakemake. It offers:
 Contributing
 ============
 
-Clone the git repository. Snakebids dependencies are managed with Poetry, which you'll need installed on your machine. You can find instructions on the [poetry website](https://python-poetry.org/docs/master/#installation). Then, setup the development environment with the following commands::
+Clone the git repository. Snakebids dependencies are managed with Poetry, which you'll need installed on your machine. You can find instructions on the [poetry website](https://python-poetry.org/docs/master/#installation). Then, setup the development environment with the following commands:
 
 ```bash
 poetry install

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 snakebids
 =========
 [![Documentation Status](https://readthedocs.org/projects/snakebids/badge/?version=latest)](https://snakebids.readthedocs.io/en/latest/?badge=latest)
+[![DOI](https://zenodo.org/badge/309495236.svg)](https://zenodo.org/badge/latestdoi/309495236)
 
 Snakemake + BIDS
 


### PR DESCRIPTION
## Proposed changes

Inspired by the [`pybids`](https://github.com/bids-standard/pybids/releases/tag/0.14.0) releases, this adds a badge for the latest associated zenodo object to both the release-drafter and readme. 

One thing I am unsure of with this PR is with future releases. Zenodo issues a new doi for each new release that is linked to the original ("concept") doi. Currently the badge is always grabbing the "latest" version, so I'm not sure if on a new release, any existing badges get updated. There might be a way to search for the matching version, but I haven't found an easy way for that yet.

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [x] Changes pass the unit tests
- [x] I have included necessary documentation or comments (as necessary)
- [x] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.