### PR TITLE
Change review assignment action (no automated follow-up review request)

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -6,6 +6,7 @@ on:
 jobs: 
   assign:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.assignee == null
 
     steps:
       - name: Assign reviewer


### PR DESCRIPTION
## Proposed changes

Resolves #148. Changes such that the reviewer assignment will trigger only if there was no assignee to the pull request. If a PR needs to be reviewed again (due to changes), users will have to manually request.

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [x] Changes pass the unit tests
- [ ] I have included necessary documentation or comments (as necessary)
- [x] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.