### PR TITLE
Better version bump

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,6 @@
 name-template: '$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
+filter-by-commitish: true
 #header: |
 #[![DOI](https://zenodo.org/badge/309495236.svg)](https://zenodo.org/badge/latestdoi/309495236)
 

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -10,11 +10,13 @@ jobs:
       - name: Checkout master branch
         uses: actions/checkout@v2
         with:
-          ref: refs/heads/main
+          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Update changelog
         uses: release-drafter/release-drafter@v5
         id: release-drafter
+        with:
+          commitish: ${{ github.event.pull_request.base.ref }}
         env:
           GITHUB_TOKEN: ${{ secrets.BP_PAT_TOKEN }}
 
@@ -73,5 +75,6 @@ jobs:
       - name: Push changes
         uses: CasperWA/push-protected@v2
         with:
+          branch: ${{ github.event.pull_request.base.ref }}
           token: ${{ secrets.BP_PAT_TOKEN }}
           unprotect_reviews: True

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,11 @@ on:
         default: "YYYY-MM-DD"
       comments:
         description: "Comments"
+        required: false
+      branch:
+        description: The branch from which to make the release
+        required: true
+        default: main
 
 jobs:
   release_changelog:
@@ -27,23 +32,25 @@ jobs:
 
       - uses: actions/checkout@master
         with:
-          ref: refs/heads/main
+          ref: ${{ github.event.inputs.branch }}
 
       - name: Draft change log
         uses: release-drafter/release-drafter@v5
         id: release-drafter
+        with:
+          commitish: ${{ github.event.inputs.branch }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set new release version
         env:
           RD_RELEASE: ${{ steps.release-drafter.outputs.name }}
-        run: | 
+        run: |
           if [ ! -z "$RD_RELEASE" ]; then
             echo "NEW_RELEASE=$RD_RELEASE" >> $GITHUB_ENV
           else
             echo "NEW_RELEASE=0.1.0" >> $GITHUB_ENV
-          fi 
+          fi
 
       - name: Update version in pyproject.toml
         uses: jacobtomlinson/gha-find-replace@master
@@ -67,15 +74,16 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git diff-index --quiet HEAD || git commit -m "Bump version to $LATEST_VERSION" -a
 
-      - name: Push changes 
+      - name: Push changes
         uses: CasperWA/push-protected@v2
         with:
           token: ${{ secrets.BP_PAT_TOKEN }}
-          unprotect_reviews: True 
+          unprotect_reviews: True
 
       - name: Publish change log
         uses: release-drafter/release-drafter@v5
         with:
+          commitish: ${{ github.event.inputs.branch }}
           publish: true
           name: ${{ env.NEW_RELEASE }}
           tag: "v${{ env.NEW_RELEASE }}"
@@ -89,7 +97,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
         with:
-          ref: refs/heads/main
+          ref: ${{ github.event.inputs.branch }}
 
       - name: Set up Python
         uses: actions/setup-python@v2

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -11,6 +11,10 @@ on:
         description: "Date"
         required: true
         default: "YYYY-MM-DD"
+      commitish:
+        description: "Target commit / branch"
+        required: true
+        default: "main"
       comments:
         description: "Update release drafter notes"
 
@@ -31,3 +35,5 @@ jobs:
         id: release-drafter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          commitish: ${{ github.event.inputs.commitish }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - uses: actions/cache@v2
       with:
         path: ~/.cache/pip
@@ -118,3 +119,15 @@ jobs:
     - name: Test with pytest
       run: |
         poetry run pytest --doctest-modules --ignore=docs --ignore=snakebids/project_template --benchmark-disable
+
+  deployment_on_base:
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.event_name, 'pull_request') }}
+    steps:
+      - name: Check for previous deployment on base
+        run: |
+          [[ $(
+            curl https://api.github.com/repos/${{ github.repository }}/releases |
+            jq '.[].target_commitish == "${{ github.event.pull_request.base.ref }}"' |
+            grep true | wc -l
+          ) != 0 ]]


### PR DESCRIPTION
## Proposed changes
Alternative approach to the issue arising in #160 and first approached in #163. See #163 for further discussion.

Bump version acts on whatever "base" a PR is merged into. This should allow maintaining multiple branches at a time, should the need arise (as it did in #160).

Both deploy and manual-release-draft workflows can now be run on any branch.