### PR TITLE
BidsInputs Refactoring

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -9,3 +9,4 @@ extend-exclude =
     .hypothesis/
     docs/
     snakebids/project_template/*/docs
+    typings/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
   - repo: local
     hooks:
       - id: flake8
-        exclude: snakebids/tests
+        exclude: snakebids/tests|typings
         entry: poetry run flake8
         language: system
         name: flake8

--- a/poetry.lock
+++ b/poetry.lock
@@ -125,6 +125,14 @@ tabulate = "*"
 termcolor = "*"
 
 [[package]]
+name = "cached-property"
+version = "1.5.2"
+description = "A decorator for caching properties in classes."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "certifi"
 version = "2022.5.18.1"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -1515,7 +1523,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.11"
-content-hash = "69e4056a68ae906c74df44729d01fb1d00281e72b5af5ded4c909d369fb11def"
+content-hash = "06fc6678a1b91fbbdbc9e87f6c07871ce1d060fb16b8cab0b53de292652c4fed"
 
 [metadata.files]
 appdirs = [
@@ -1572,6 +1580,10 @@ black = [
 ]
 boutiques = [
     {file = "boutiques-0.5.25-py2.py3-none-any.whl", hash = "sha256:1a29e5b0e786f1904ebb8d767fbe6189a59865dff120ffe76d141bbea1043b04"},
+]
+cached-property = [
+    {file = "cached-property-1.5.2.tar.gz", hash = "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130"},
+    {file = "cached_property-1.5.2-py2.py3-none-any.whl", hash = "sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0"},
 ]
 certifi = [
     {file = "certifi-2022.5.18.1-py3-none-any.whl", hash = "sha256:f1d53542ee8cbedbe2118b5686372fb33c297fcd6379b050cca0ef13a597382a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ typing-extensions = "^3.10.0"
 attrs = "^21.2.0"
 boutiques = "^0.5.25"
 more-itertools = "^8.12.0"
+cached-property = "^1.5.2"
 
 [tool.poetry.dev-dependencies]
 black = "^22.1.0"
@@ -56,7 +57,8 @@ profile = "black"
 multi_line_output = 3
 
 [tool.pylint.master]
-ignore-patterns = "^[0-9][0-9]+_,^test_,^__init__"
+ignore-patterns = "^[0-9][0-9]+_,^test_,^__init__,"
+ignore-paths = ["typings"]
 
 [tool.pylint.format]
 good-names = "i,j,k,ex,_,x,y,f,d"

--- a/snakebids/__init__.py
+++ b/snakebids/__init__.py
@@ -3,8 +3,9 @@ __submodules__ = ["core"]
 
 # <AUTOGEN_INIT>
 from snakebids.core import (
-    BidsInputs,
-    BidsInputsDict,
+    BidsComponent,
+    BidsDataset,
+    BidsDatasetDict,
     bids,
     filter_list,
     generate_inputs,
@@ -15,8 +16,9 @@ from snakebids.core import (
 )
 
 __all__ = [
-    "BidsInputs",
-    "BidsInputsDict",
+    "BidsComponent",
+    "BidsDataset",
+    "BidsDatasetDict",
     "bids",
     "filter_list",
     "generate_inputs",

--- a/snakebids/core/__init__.py
+++ b/snakebids/core/__init__.py
@@ -7,16 +7,18 @@ __ignore__ = ["T_co"]
 from snakebids.core.construct_bids import bids, print_boilerplate
 from snakebids.core.filtering import filter_list, get_filtered_ziplist_index
 from snakebids.core.input_generation import (
-    BidsInputs,
-    BidsInputsDict,
+    BidsComponent,
+    BidsDataset,
+    BidsDatasetDict,
     generate_inputs,
     get_wildcard_constraints,
     write_derivative_json,
 )
 
 __all__ = [
-    "BidsInputs",
-    "BidsInputsDict",
+    "BidsComponent",
+    "BidsDataset",
+    "BidsDatasetDict",
     "bids",
     "filter_list",
     "generate_inputs",

--- a/snakebids/tests/helpers.py
+++ b/snakebids/tests/helpers.py
@@ -2,7 +2,42 @@
 """
 
 from collections import UserDict
-from typing import Dict
+from typing import Any, Dict, Iterable, List, Tuple
+
+
+def get_zip_list(entities: Iterable[str], combinations: Iterable[Tuple[str, ...]]):
+    """Return a zip list from iterables of entities and value combinations
+
+    Parameters
+    ----------
+    entities : Iterable[str]
+        Iterable of entities
+    combinations : Iterable[Tuple[str, ...]]
+        Iterable of combinations (e.g. produced using itertools.product). Each tuple
+        must be the same length as entities
+
+    Returns
+    -------
+    Dict[str, List[str]]
+        zip_list representation of entity-value combinations
+    """
+    return {entity: list(combs) for entity, combs in zip(entities, zip(*combinations))}
+
+
+def setify(dic: Dict[Any, List[Any]]):
+    """Convert a dict of *->lists into a dict of *->sets
+
+    Parameters
+    ----------
+    dic : Dict[Any, List[Any]]
+        Dict of lists to convert
+
+    Returns
+    -------
+    Dict[Any, Set[Any]]
+        Dict of sets
+    """
+    return {key: set(val) for key, val in dic.items()}
 
 
 class BidsListCompare(UserDict):

--- a/snakebids/tests/helpers.py
+++ b/snakebids/tests/helpers.py
@@ -4,6 +4,8 @@
 from collections import UserDict
 from typing import Any, Dict, Iterable, List, Tuple
 
+from snakebids import bids
+
 
 def get_zip_list(entities: Iterable[str], combinations: Iterable[Tuple[str, ...]]):
     """Return a zip list from iterables of entities and value combinations
@@ -38,6 +40,22 @@ def setify(dic: Dict[Any, List[Any]]):
         Dict of sets
     """
     return {key: set(val) for key, val in dic.items()}
+
+
+def get_bids_path(entities: Iterable[str]):
+    """Get consistently ordered bids path for a group of entities
+
+    Parameters
+    ----------
+    entities : Iterable[str]
+        Entities to convert into a bids path
+
+    Returns
+    -------
+    str
+        bids path
+    """
+    return bids(root=".", **{entity: f"{{{entity}}}" for entity in sorted(entities)})
 
 
 class BidsListCompare(UserDict):

--- a/snakebids/tests/strategies.py
+++ b/snakebids/tests/strategies.py
@@ -1,0 +1,82 @@
+import itertools as it
+from typing import Any, Dict, List, Type, cast
+
+import hypothesis.strategies as st
+from bids.layout import Config as BidsConfig
+
+from snakebids import BidsComponent, bids
+from snakebids.tests.helpers import get_zip_list
+
+
+def bids_entity():
+    bidsconfig = BidsConfig.load("bids")
+    return st.sampled_from(cast(str, list(bidsconfig.entities.keys())))
+
+
+def bids_value():
+    bids_alphabet = st.characters(whitelist_categories=["Ll", "Lu", "Nd"])
+    return st.text(bids_alphabet, min_size=1, max_size=10)
+
+
+def bids_entity_list(min_size: int = 1):
+    return st.lists(
+        bids_entity(),
+        min_size=min_size,
+        max_size=5,
+        unique=True,
+    )
+
+
+def get_bids_path(zip_lists: Dict[str, List[str]]):
+    return bids(root=".", **{entity: f"{{{entity}}}" for entity in zip_lists})
+
+
+@st.composite
+def bids_input(draw: st.DrawFn):
+    # Generate multiple entity sets for different "file types"
+
+    entities = draw(bids_entity_list())
+
+    values = {
+        key: draw(st.lists(bids_value(), min_size=1, unique=True)) for key in entities
+    }
+
+    combinations = list(it.product(*values.values()))
+    used_combinations = draw(
+        st.lists(
+            st.sampled_from(combinations),
+            min_size=1,
+            max_size=len(combinations),
+            unique=True,
+        )
+    )
+    zip_lists = get_zip_list(values, used_combinations)
+
+    path = get_bids_path(zip_lists)
+
+    return BidsComponent(
+        input_name=draw(bids_value()),
+        input_path=path,
+        input_zip_lists=zip_lists,
+    )
+
+
+@st.composite
+def bids_input_lists(draw: st.DrawFn, min_size: int = 1, max_size: int = 5):
+    # Generate multiple entity sets for different "file types"
+    entities = draw(bids_entity_list(min_size))
+
+    return {
+        key: draw(
+            st.lists(bids_value(), min_size=min_size, max_size=max_size, unique=True)
+        )
+        for key in entities
+    }
+
+
+def everything_except(*excluded_types: Type[Any]):
+    return (
+        st.from_type(type)
+        .flatmap(st.from_type)
+        .filter(lambda s: not isinstance(s, excluded_types))
+    )

--- a/snakebids/utils/sb_itertools.py
+++ b/snakebids/utils/sb_itertools.py
@@ -1,0 +1,35 @@
+import itertools as it
+from typing import Iterable, Sequence, TypeVar
+
+import more_itertools as itx
+
+T = TypeVar("T")
+
+
+def unpack(iterable: Iterable[T], default: Sequence[T]) -> Iterable[T]:
+    """Return default if iterable has no elements
+
+    Allows safe unpacking of possibly empty iterables
+
+    Parameters
+    ----------
+    iterable : Iterable[T]
+        Iterable to unpack
+    default : Sequence[T]
+        Values to return if then length of iterable is 0
+
+    Returns
+    -------
+    Iterable[T]
+    """
+    first, second = it.tee(iterable, 2)
+    if itx.ilen(first):
+        return second
+    return default
+
+
+# pylint: disable=invalid-name
+def drop(n: int, iterable: Iterable[T]) -> Iterable[T]:
+    first, second = it.tee(iterable, 2)
+    keep = itx.ilen(first) - n
+    return itx.take(max(0, keep), second)

--- a/typings/cached_property.pyi
+++ b/typings/cached_property.pyi
@@ -1,0 +1,5 @@
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+
+def cached_property(func: Callable[..., T]) -> T: ...


### PR DESCRIPTION
## Proposed changes

Split `BidsInputs` into two classes: a smaller class describing a single dataset component and containing the lists, zip_lists, wildcard dict, and path, and a wrapper class compiling them together that takes the same API as `BidsInputs`. The inner class I've called `BidsComponent` and the wrapper I've called `BidsDataset`. The alternative name for the wrapper was `BidsComponents` (pluralized), but I found it confusing from a documentation perspective, and I think `BidsDataset` is more descriptive.

This new structure cleans up the implementation details in a few ways:

1. The old internal `_BidsLists` named tuple is no longer necessary and has been removed.
2. `input_lists` and `input_wildcards` are now defined in terms of `input_zip_lists`. This will make modification of the dataset (e.g. filtering) much easier, as now only one entry needs to be modified.
3. `BidsComponent` is equipped with an `__eq__()` operator, making testing much easier. Most of the tests in `test_generate_inputs.py` have been modified to take advantage of this new behaviour

Finally, this opens up new ways of interacting with datasets. The previous syntax (e.g. `inputs.input_lists["t1w"]`) will still work, but because `BidsDataset` is implented as a dict, a reverse syntax is also possible (e.g. `inputs["t1w"].input_lists`). This new syntax is possibly more intuitive.

## Backward Compatibility

As `BidsInputs` was always the return of `generate_inputs()` and never intended to be directly accessed, this change should not affect any existing workflows. If anyone feels it necessary, it should be possible to have a stub `BidsInputs` whose `__new__()` returns a copy of `BidsDataset`.

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [x] Changes pass the unit tests
- [x] I have included necessary documentation or comments (as necessary)
- [x] Any dependent changes have been merged and published
