### PR TITLE
Add minimal fixes to get logging working

### DIFF
--- a/snakebids/_logging.py
+++ b/snakebids/_logging.py
@@ -1,0 +1,12 @@
+import logging
+from typing import Union
+
+
+def setup_logging(level: Union[str, int] = logging.DEBUG):
+    logger = logging.getLogger("snakebids")
+    stream_handler = logging.StreamHandler()
+    formatter = logging.Formatter("%(levelname)-8s %(message)s")
+    stream_handler.setFormatter(formatter)
+
+    logger.addHandler(stream_handler)
+    logger.setLevel(level)

--- a/snakebids/admin.py
+++ b/snakebids/admin.py
@@ -1,14 +1,18 @@
 """Script to generate a Snakebids project."""
 
 import argparse
+import logging
 import os
 from pathlib import Path
 
 from cookiecutter.main import cookiecutter
 
 import snakebids
+from snakebids._logging import setup_logging
 from snakebids.app import SnakeBidsApp
 from snakebids.cli import add_dynamic_args
+
+logger = logging.getLogger(__name__)
 
 
 def create_app(_):
@@ -20,7 +24,7 @@ def create_descriptor(args):
     app = SnakeBidsApp(args.app_dir.resolve())
     add_dynamic_args(app.parser, app.config["parse_args"], app.config["pybids_inputs"])
     app.create_descriptor(args.out_path)
-    print(f"Boutiques descriptor created at {args.out_path}")
+    logger.info("Boutiques descriptor created at %s", args.out_path)
 
 
 def gen_parser():
@@ -53,7 +57,7 @@ def gen_parser():
 
 def main():
     """Invoke Cookiecutter on the Snakebids project template."""
-
+    setup_logging()
     parser = gen_parser()
     args = parser.parse_args()
     args.func(args)

--- a/snakebids/cli.py
+++ b/snakebids/cli.py
@@ -13,7 +13,7 @@ import snakemake
 # either Path or pathlib.Path
 Path = pathlib.Path
 
-logger = logging.Logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 # pylint: disable=too-few-public-methods,


### PR DESCRIPTION
There was previously no central initializing of handlers for logging, so only WARNING and higher was getting logged and without a modicum of formatting.

This adds a centralized _logging module to initialize the base logger. This gets called at the two app entrypoints: snakebids.admin:main and upon initialization of SnakebidsApp

I've never implemented logging before, so I wasn't sure of the "correct" way to do it; if anyone has suggestions, let me know. Obviously the system could get more sophisticated, especially with colors, etc, but this gets the basics working.
