### PR TITLE
Migrate poetry syntax to poetry v1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This package allows you to build BIDS Apps using Snakemake. It offers:
 Contributing
 ============
 
-Clone the git repository. Snakebids dependencies are managed with Poetry, which you'll need installed on your machine. You can find instructions on the [poetry website](https://python-poetry.org/docs/master/#installation). Then, setup the development environment with the following commands:
+Clone the git repository. Snakebids dependencies are managed with Poetry (vesion 1.2 or higher), which you'll need installed on your machine. You can find instructions on the [poetry website](https://python-poetry.org/docs/master/#installation). Then, setup the development environment with the following commands:
 
 ```bash
 poetry install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ cached-property = "^1.5.2"
 # for py310, so force a higher version on py37.1 and above
 pandas = {version = ">=1.3", python = ">=3.7.1"}
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 black = "^22.1.0"
 pybids = "^0.15.2"
 pytest = "^7.0.0"


### PR DESCRIPTION
Really simple one, just updating the `pyproject.toml` to poetry 1.2. This prevents us from using poetry 1.1, so if anyone needs to stay legacy, speak now :smiley: