### PR TITLE
Fix docstring type in _get_lists_from_bids

### DIFF
--- a/snakebids/core/input_generation.py
+++ b/snakebids/core/input_generation.py
@@ -905,8 +905,8 @@ def _get_lists_from_bids(
 
     Yields
     ------
-    BidsLists:
-        One BidsLists is yielded for each modality described by ``pybids_inputs``.
+    BidsComponent:
+        One BidsComponent is yielded for each modality described by ``pybids_inputs``.
     """
     if limit_to is None:
         limit_to = pybids_inputs.keys()


### PR DESCRIPTION
Trivial change in one of the docstrings which had the wrong return type