### PR TITLE
Skip Bids Indexing when `custom_paths` specified

### DIFF
--- a/snakebids/core/input_generation.py
+++ b/snakebids/core/input_generation.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 """Utilities for converting Snakemake apps to BIDS apps."""
 
 import json
@@ -15,6 +16,7 @@ from typing_extensions import Literal
 from snakebids.core.datasets import BidsComponent, BidsDataset, BidsDatasetDict
 from snakebids.core.filtering import filter_list
 from snakebids.exceptions import ConfigError
+from snakebids.types import InputsConfig
 from snakebids.utils.snakemake_io import glob_wildcards
 from snakebids.utils.utils import BidsEntity
 
@@ -25,7 +27,7 @@ _logger = logging.getLogger(__name__)
 @overload
 def generate_inputs(
     bids_dir,
-    pybids_inputs,
+    pybids_inputs: InputsConfig,
     pybids_database_dir=...,
     pybids_reset_database=...,
     derivatives=...,
@@ -42,7 +44,7 @@ def generate_inputs(
 @overload
 def generate_inputs(
     bids_dir,
-    pybids_inputs,
+    pybids_inputs: InputsConfig,
     pybids_database_dir=...,
     pybids_reset_database=...,
     derivatives=...,
@@ -58,7 +60,7 @@ def generate_inputs(
 # pylint: disable=too-many-arguments
 def generate_inputs(
     bids_dir,
-    pybids_inputs,
+    pybids_inputs: InputsConfig,
     pybids_database_dir=None,
     pybids_reset_database=False,
     derivatives=False,
@@ -294,11 +296,11 @@ def generate_inputs(
 
 
 def _gen_bids_layout(
-    bids_dir,
-    derivatives,
-    pybids_database_dir,
-    pybids_reset_database,
-    pybids_config=None,
+    bids_dir: Union[Path, str],
+    derivatives: bool,
+    pybids_database_dir: Union[Path, str, None],
+    pybids_reset_database: bool,
+    pybids_config: Union[Path, str, None] = None,
 ):
     """Create (or reindex) the BIDSLayout if one doesn't exist,
     which is only saved if a database directory path is provided

--- a/snakebids/resources/bids_tags.json
+++ b/snakebids/resources/bids_tags.json
@@ -41,11 +41,11 @@
     },
     "run": {
         "tag": "run",
-        "pattern": "[0-9]+"
+        "pattern": "[0-9]{1,5}"
     },
     "chunk": {
         "tag": "chunk",
-        "pattern": "[0-9]+"
+        "pattern": "[0-9]{1,5}"
     },
     "proc": {
         "tag": "proc",
@@ -57,15 +57,15 @@
     },
     "echo": {
         "tag": "echo",
-        "pattern": "[0-9]+"
+        "pattern": "[0-9]{1,5}"
     },
     "flip": {
         "tag": "flip",
-        "pattern": "[0-9]+"
+        "pattern": "[0-9]{1,5}"
     },
     "inv": {
         "tag": "inv",
-        "pattern": "[0-9]+"
+        "pattern": "[0-9]{1,5}"
     },
     "mt": {
         "tag": "mt",

--- a/snakebids/tests/conftest.py
+++ b/snakebids/tests/conftest.py
@@ -3,6 +3,7 @@ import tempfile
 from pathlib import Path
 from typing import Optional
 
+import bids.layout
 import pytest
 from pyfakefs.fake_filesystem import FakeFilesystem
 
@@ -40,3 +41,12 @@ def fakefs_tmpdir(request: pytest.FixtureRequest, fakefs: Optional[FakeFilesyste
     if not fakefs:
         return request.getfixturevalue("tmpdir")
     return Path(tempfile.mkdtemp())
+
+
+@pytest.fixture
+def bids_fs(fakefs: Optional[FakeFilesystem]):
+    if fakefs:
+        f = Path(*bids.layout.__path__, "config")
+        fakefs.add_real_file(f / "bids.json")
+        fakefs.add_real_file(f / "derivatives.json")
+    return fakefs

--- a/snakebids/tests/strategies.py
+++ b/snakebids/tests/strategies.py
@@ -1,10 +1,14 @@
+import copy
 import itertools as it
+from pathlib import Path
 from typing import Any, List, Optional, Type
 
 import hypothesis.strategies as st
 from bids.layout import Config as BidsConfig
+from hypothesis import assume
 
 from snakebids.core.datasets import BidsComponent
+from snakebids.core.input_generation import BidsDataset
 from snakebids.tests import helpers
 from snakebids.utils.utils import BidsEntity
 
@@ -80,6 +84,7 @@ def bids_components(
     min_size: int = 1,
     max_size: int = 5,
     entities: Optional[List[BidsEntity]] = None,
+    root: Optional[Path] = None,
     restricted_chars: bool = False,
 ):
     zip_lists = draw(
@@ -91,11 +96,11 @@ def bids_components(
         )
     )
 
-    path = helpers.get_bids_path(zip_lists)
+    path = (root or Path()) / helpers.get_bids_path(zip_lists)
 
     return BidsComponent(
         name=draw(bids_value()),
-        path=path,
+        path=str(path),
         zip_lists=zip_lists,
     )
 
@@ -125,3 +130,31 @@ def everything_except(*excluded_types: Type[Any]):
         .flatmap(st.from_type)
         .filter(lambda s: not isinstance(s, excluded_types))
     )
+
+
+@st.composite
+def datasets(draw: st.DrawFn, root: Optional[Path] = None):
+    ent1 = draw(bids_entity_lists(min_size=2, max_size=3))
+    assume("datatype" not in ent1)
+    # Currently, space and ce cannot coexist because ce is a substr of space (see
+    # snakebids.core.input_generation:_parse_bids_path)
+    assume(not ("space" in ent1 and "ceagent" in ent1))
+    ent2 = copy.copy(ent1)
+    ent2.pop()
+    # BUG: snakebids currently doesn't properly parse paths with just suffix
+    assume(ent2 != ["suffix"])
+    comp1 = draw(bids_components(entities=ent1, restricted_chars=True, root=root))
+    comp2 = draw(bids_components(entities=ent2, restricted_chars=True, root=root))
+    assume(comp1.input_name != comp2.input_name)
+    return BidsDataset.from_iterable([comp1, comp2])
+
+
+@st.composite
+def datasets_one_comp(draw: st.DrawFn, root: Optional[Path] = None):
+    ent1 = draw(bids_entity_lists(min_size=2, max_size=3))
+    assume("datatype" not in ent1)
+    # Currently, space and ce cannot coexist because ce is a substr of space (see
+    # snakebids.core.input_generation:_parse_bids_path)
+    assume(not ("space" in ent1 and "ceagent" in ent1))
+    comp1 = draw(bids_components(entities=ent1, restricted_chars=True, root=root))
+    return BidsDataset.from_iterable([comp1])

--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -31,6 +31,8 @@ from snakebids.core.input_generation import (
 from snakebids.exceptions import ConfigError
 from snakebids.tests import strategies as sb_st
 from snakebids.tests.helpers import BidsListCompare, debug, get_bids_path, get_zip_list
+from snakebids.types import InputsConfig
+from snakebids.utils import sb_itertools as sb_it
 from snakebids.utils.utils import BidsEntity
 
 T = TypeVar("T")
@@ -107,7 +109,7 @@ class TestFilterBools:
         root = tempfile.mkdtemp(dir=tmpdir)
         self.create_dataset(root, dataset)
         shorter, _ = self.disambiguate_components(dataset)
-        pybids_inputs: Dict[str, Dict[str, Any]] = {
+        pybids_inputs: InputsConfig = {
             shorter.input_name: {
                 "wildcards": [
                     BidsEntity.from_tag(wildcard).entity
@@ -133,7 +135,7 @@ class TestFilterBools:
         root = tempfile.mkdtemp(dir=tmpdir)
         self.create_dataset(root, dataset)
         _, longer = self.disambiguate_components(dataset)
-        pybids_inputs: Dict[str, Dict[str, Any]] = {
+        pybids_inputs: InputsConfig = {
             longer.input_name: {
                 "wildcards": [
                     BidsEntity.from_tag(wildcard).entity
@@ -160,7 +162,7 @@ class TestFilterBools:
         self.create_dataset(root, dataset)
         shorter, _ = self.disambiguate_components(dataset)
         extra_entity = self.get_extra_entity(dataset)
-        pybids_inputs: Dict[str, Dict[str, Any]] = {
+        pybids_inputs: InputsConfig = {
             shorter.input_name: {
                 "wildcards": [
                     BidsEntity.from_tag(wildcard).entity
@@ -194,7 +196,7 @@ class TestFilterBools:
         self.create_dataset(root, dataset)
         _, longer = self.disambiguate_components(dataset)
         extra_entity = self.get_extra_entity(dataset)
-        pybids_inputs: Dict[str, Dict[str, Any]] = {
+        pybids_inputs: InputsConfig = {
             longer.input_name: {
                 "wildcards": [
                     BidsEntity.from_tag(wildcard).entity
@@ -235,7 +237,7 @@ class TestAbsentConfigEntries:
 
         # create config
         derivatives = False
-        pybids_inputs = {
+        pybids_inputs: InputsConfig = {
             "t1": {
                 "wildcards": ["acquisition", "subject"],
             }
@@ -261,7 +263,7 @@ class TestAbsentConfigEntries:
 
         # create config
         derivatives = False
-        pybids_inputs = {
+        pybids_inputs: InputsConfig = {
             "t1": {
                 "filters": {"acquisition": "foo", "subject": "001"},
             }
@@ -517,7 +519,7 @@ def test_custom_pybids_config(tmpdir: Path):
 
     # create config
     derivatives = False
-    pybids_inputs = {
+    pybids_inputs: InputsConfig = {
         "t1": {
             "filters": {"suffix": "T1w"},
             "wildcards": ["acquisition", "subject", "foo"],
@@ -557,7 +559,7 @@ def test_t1w():
     # create config
     real_bids_dir = "snakebids/tests/data/bids_t1w"
     derivatives = False
-    pybids_inputs = {
+    pybids_inputs: InputsConfig = {
         "t1": {
             "filters": {"suffix": "T1w"},
             "wildcards": ["acquisition", "subject", "session", "run"],
@@ -601,7 +603,7 @@ def test_t1w():
     assert result.sessions == []
     assert result.subj_wildcards == {"subject": "{subject}"}
 
-    pybids_inputs_suffix = {
+    pybids_inputs_suffix: InputsConfig = {
         "scan": {
             "filters": {},
             "wildcards": [
@@ -715,7 +717,7 @@ def test_t1w_with_dict():
     # create config
     real_bids_dir = "snakebids/tests/data/bids_t1w"
     derivatives = False
-    pybids_inputs = {
+    pybids_inputs: InputsConfig = {
         "t1": {
             "filters": {"suffix": "T1w"},
             "wildcards": ["acquisition", "subject", "session", "run"],
@@ -741,7 +743,7 @@ def test_t1w_with_dict():
     assert config["sessions"] == []
     assert config["subj_wildcards"] == {"subject": "{subject}"}
 
-    pybids_inputs_suffix = {
+    pybids_inputs_suffix: InputsConfig = {
         "scan": {
             "filters": {},
             "wildcards": [

--- a/snakebids/types.py
+++ b/snakebids/types.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing_extensions import TypeAlias, TypedDict
+
+
+class InputConfig(TypedDict, total=False):
+    """Configuration passed in snakebids.yaml file"""
+
+    filters: dict[str, str | bool | list[str]]
+    wildcards: list[str]
+    custom_path: str
+
+
+InputsConfig: TypeAlias = "dict[str, InputConfig]"


### PR DESCRIPTION
Skip Bids Indexing when all components have `custom_paths` specified. Also add a bunch of related tests, which incidentally covers some E2E cases.

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [ ] Changes have been tested to ensure that fix is effective or that a feature works.
- [ ] Changes pass the unit tests
- [ ] I have included necessary documentation or comments (as necessary)
- [ ] Any dependent changes have been merged and published
