### PR TITLE
Block components with same names in dataset init

### DIFF
--- a/snakebids/core/datasets.py
+++ b/snakebids/core/datasets.py
@@ -191,7 +191,7 @@ class BidsDataset(_BidsComponentsType):
 
     # pylint: disable=super-init-not-called
     def __init__(self, data: Any):
-        self.data = dict(data)
+        self.data = dict(data)  # type: ignore
 
     def __setitem__(self, _: Any, __: Any):
         raise NotImplementedError(
@@ -255,8 +255,7 @@ class BidsDataset(_BidsComponentsType):
             }
         ]
 
-    @property
-    # @ft.lru_cache(None)
+    @cached_property
     def sessions(self):
         """A list of the sessions in the dataset."""
         return [
@@ -269,8 +268,7 @@ class BidsDataset(_BidsComponentsType):
             }
         ]
 
-    @property
-    # @ft.lru_cache(None)
+    @cached_property
     def subj_wildcards(self):
         """The subject and session wildcards applicable to this dataset.
 
@@ -317,4 +315,8 @@ class BidsDataset(_BidsComponentsType):
         -------
         BidsDataset
         """
-        return cls({bidsinput.name: bidsinput for bidsinput in iterable})
+        components = list(iterable)
+        indexed = {bidsinput.name: bidsinput for bidsinput in components}
+        if not len(components) == len(indexed):
+            raise ValueError("All BidsComponents must have different names")
+        return cls(indexed)

--- a/snakebids/core/datasets.py
+++ b/snakebids/core/datasets.py
@@ -7,6 +7,7 @@ from string import Formatter
 from typing import TYPE_CHECKING, Any, Iterable, Optional, Union, cast
 
 import attr
+import more_itertools as itx
 from cached_property import cached_property
 from typing_extensions import TypedDict
 
@@ -318,5 +319,7 @@ class BidsDataset(_BidsComponentsType):
         components = list(iterable)
         indexed = {bidsinput.name: bidsinput for bidsinput in components}
         if not len(components) == len(indexed):
-            raise ValueError("All BidsComponents must have different names")
+            raise ValueError(
+                list(itx.duplicates_everseen([c.name for c in components]))
+            )
         return cls(indexed)

--- a/snakebids/core/input_generation.py
+++ b/snakebids/core/input_generation.py
@@ -17,7 +17,7 @@ from snakebids.core.filtering import filter_list
 from snakebids.exceptions import ConfigError
 from snakebids.types import InputsConfig
 from snakebids.utils.snakemake_io import glob_wildcards
-from snakebids.utils.utils import BidsEntity, BidsParseError
+from snakebids.utils.utils import BidsEntity, BidsParseError, surround
 
 _logger = logging.getLogger(__name__)
 
@@ -297,7 +297,10 @@ def generate_inputs(
     try:
         dataset = BidsDataset.from_iterable(bids_inputs)
     except ValueError as err:
-        raise ConfigError(err.args[0]) from err
+        raise ConfigError(
+            "Multiple components found with the same name: "
+            + ", ".join(surround(err.args[0], "'"))
+        ) from err
 
     if use_bids_inputs:
         return dataset

--- a/snakebids/core/input_generation.py
+++ b/snakebids/core/input_generation.py
@@ -56,7 +56,7 @@ def generate_inputs(
     ...
 
 
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments, too-many-locals
 def generate_inputs(
     bids_dir,
     pybids_inputs: InputsConfig,
@@ -293,9 +293,15 @@ def generate_inputs(
             "silence this warning."
         )
         use_bids_inputs = False
+
+    try:
+        dataset = BidsDataset.from_iterable(bids_inputs)
+    except ValueError as err:
+        raise ConfigError(err.args[0]) from err
+
     if use_bids_inputs:
-        return BidsDataset.from_iterable(bids_inputs)
-    return BidsDataset.from_iterable(bids_inputs).as_dict
+        return dataset
+    return dataset.as_dict
 
 
 def _all_custom_paths(config: InputsConfig):

--- a/snakebids/tests/test_datasets.py
+++ b/snakebids/tests/test_datasets.py
@@ -14,6 +14,13 @@ from snakebids.utils import sb_itertools as sb_it
 from snakebids.utils.utils import BidsEntity
 
 
+def test_multiple_components_cannot_have_same_name():
+    comp1 = BidsComponent("foo", path=".", zip_lists={})
+    comp2 = BidsComponent("foo", path=".", zip_lists={})
+    with pytest.raises(ValueError):
+        BidsDataset.from_iterable([comp1, comp2])
+
+
 class TestBidsComponentAliases:
     @given(sb_st.bids_components())
     def test_bids_component_aliases_are_correctly_set(self, component: BidsComponent):

--- a/snakebids/utils/utils.py
+++ b/snakebids/utils/utils.py
@@ -7,6 +7,7 @@ import re
 from typing import Any, Callable, Dict, Iterable, TypeVar
 
 import attrs
+import more_itertools as itx
 from typing_extensions import Protocol
 
 from snakebids.utils.sb_typing import UserProperty
@@ -257,3 +258,9 @@ def property_alias(prop: _Documented, label: str | None = None, ref: str | None 
         return alias
 
     return inner
+
+
+def surround(__s: Iterable[str] | str, __object: str) -> Iterable[str]:
+    """Surround a string or each string in an iterable with characters"""
+    for item in itx.always_iterable(__s):
+        yield __object + item + __object


### PR DESCRIPTION
BidsDataset.from_iterable was blindly converting the iterable of components passed into a dict. If any of these components had the same name, they would overlap in the dict (since the name is used as a key), and the first would be silently removed.

Fix this by checking for duplicate names.

Resolves #181


## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [x] Changes pass the unit tests
- [x] I have included necessary documentation or comments (as necessary)
- [x] Any dependent changes have been merged and published