### PR TITLE
Use entity-specific parsers

### DIFF
--- a/snakebids/core/datasets.py
+++ b/snakebids/core/datasets.py
@@ -63,7 +63,7 @@ class BidsComponent:
         if fields != set(value):
             raise ValueError(
                 "zip_lists entries must match the wildcards in input_path: "
-                f"Path: {fields} != zip_lists: {set(value)}"
+                f"{self.path}: {fields} != zip_lists: {set(value)}"
             )
 
     @property

--- a/snakebids/core/input_generation.py
+++ b/snakebids/core/input_generation.py
@@ -516,7 +516,6 @@ def _parse_bids_path(path: str, entities: Iterable[str]) -> Tuple[str, Dict[str,
 
     wildcard_values: Dict[str, str] = {}
 
-    # BUG: No support for "datatype"
     for entity in map(BidsEntity, entities):
         # Iterate over wildcards, slowly updating the path as each entity is replaced
 

--- a/snakebids/resources/bids_tags.json
+++ b/snakebids/resources/bids_tags.json
@@ -1,96 +1,190 @@
 {
     "subject": {
         "tag": "sub",
-        "pattern": "[a-zA-Z0-9]+"
+        "before": "[/\\\\]+sub-",
+        "match": "[a-zA-Z0-9]+"
     },
     "session": {
         "tag": "ses",
-        "pattern": "[a-zA-Z0-9]+"
+        "before": "[_/\\\\]+ses-",
+        "match": "[a-zA-Z0-9]+"
     },
     "sample": {
         "tag": "sample",
-        "pattern": "[a-zA-Z0-9]+"
+        "before": "[_/\\\\]+sample-",
+        "match": "[a-zA-Z0-9]+"
     },
     "task": {
         "tag": "task",
-        "pattern": "[a-zA-Z0-9]+"
-    },
-    "tracer": {
-        "tag": "trc",
-        "pattern": "[a-zA-Z0-9]+"
+        "before": "[_/\\\\]+task-",
+        "match": "[a-zA-Z0-9]+"
     },
     "acquisition": {
         "tag": "acq",
-        "pattern": "[a-zA-Z0-9]+"
-    },
-    "staining": {
-        "tag": "stain",
-        "pattern": "[a-zA-Z0-9]+"
+        "before": "[_/\\\\]+acq-",
+        "match": "[a-zA-Z0-9]+"
     },
     "ceagent": {
         "tag": "ce",
-        "pattern": "[a-zA-Z0-9]+"
+        "before": "[_/\\\\]+ce-",
+        "match": "[a-zA-Z0-9]+"
+    },
+    "staining": {
+        "tag": "stain",
+        "before": "[_/\\\\]+stain-",
+        "match": "[a-zA-Z0-9]+"
+    },
+    "tracer": {
+        "tag": "trc",
+        "before": "[_/\\\\]+trc-",
+        "match": "[a-zA-Z0-9]+"
     },
     "reconstruction": {
         "tag": "rec",
-        "pattern": "[a-zA-Z0-9]+"
+        "before": "[_/\\\\]+rec-",
+        "match": "[a-zA-Z0-9]+"
     },
     "direction": {
         "tag": "dir",
-        "pattern": "[a-zA-Z0-9]+"
+        "before": "[_/\\\\]+dir-",
+        "match": "[a-zA-Z0-9]+"
     },
     "run": {
         "tag": "run",
-        "pattern": "[0-9]{1,5}"
-    },
-    "chunk": {
-        "tag": "chunk",
-        "pattern": "[0-9]{1,5}"
+        "before": "[_/\\\\]+run-",
+        "match": "[0-9]{1,5}"
     },
     "proc": {
         "tag": "proc",
-        "pattern": "[a-zA-Z0-9]+"
+        "before": "[_/\\\\]+proc-",
+        "match": "[a-zA-Z0-9]+"
     },
     "modality": {
         "tag": "mod",
-        "pattern": "[a-zA-Z0-9]+"
+        "before": "[_/\\\\]+mod-",
+        "match": "[a-zA-Z0-9]+"
     },
     "echo": {
         "tag": "echo",
-        "pattern": "[0-9]{1,5}"
+        "before": "[_/\\\\]+echo-",
+        "match": "[0-9]{1,5}"
     },
     "flip": {
         "tag": "flip",
-        "pattern": "[0-9]{1,5}"
+        "before": "[_/\\\\]+flip-",
+        "match": "[0-9]{1,5}"
     },
     "inv": {
         "tag": "inv",
-        "pattern": "[0-9]{1,5}"
+        "before": "[_/\\\\]+inv-",
+        "match": "[0-9]{1,5}"
     },
     "mt": {
         "tag": "mt",
-        "pattern": "(on|off)"
-    },
-    "space": {
-        "tag": "space",
-        "pattern": "[a-zA-Z0-9]+"
-    },
-    "split": {
-        "tag": "split",
-        "pattern": "[a-zA-Z0-9]+"
-    },
-    "recording": {
-        "tag": "recording",
-        "pattern": "[a-zA-Z0-9]+"
-    },
-    "datatype": {
-        "pattern": "anat|beh|dwi|eeg|fmap|func|ieeg|meg|micr|perf|pet"
-    },
-    "suffix": {
-        "pattern": "[a-zA-Z0-9]*?"
+        "before": "[_/\\\\]+mt-",
+        "match": "on|off"
     },
     "part": {
         "tag": "part",
-        "pattern": "imag|mag|phase|real"
+        "before": "[_/\\\\]+part-",
+        "match": "imag|mag|phase|real"
+    },
+    "recording": {
+        "tag": "recording",
+        "before": "[_/\\\\]+recording-",
+        "match": "[a-zA-Z0-9]+"
+    },
+    "space": {
+        "tag": "space",
+        "before": "[_/\\\\]+space-",
+        "match": "[a-zA-Z0-9]+"
+    },
+    "chunk": {
+        "tag": "chunk",
+        "before": "[_/\\\\]+chunk-",
+        "match": "[0-9]{1,5}"
+    },
+    "suffix": {
+        "before": "[._]*",
+        "match": "[a-zA-Z0-9]*?",
+        "after": "\\.[^/\\\\]+$"
+    },
+    "datatype": {
+        "before": "[/\\\\]+",
+        "match": "anat|beh|dwi|eeg|fmap|func|ieeg|meg|micr|perf|pet",
+        "after": "[/\\\\]+"
+    },
+    "extension": {
+        "before": "[._]*[a-zA-Z0-9]*?",
+        "match": "[._]*[a-zA-Z0-9]*?(\\.[^/\\\\]+)$",
+        "after": "$"
+    },
+    "split": {
+        "tag": "split",
+        "before": "[_/\\\\]+split-",
+        "match": "[a-zA-Z0-9]+"
+    },
+    "atlas": {
+        "tag": "atlas",
+        "before": "atlas-",
+        "match": "[a-zA-Z0-9]+"
+    },
+    "roi": {
+        "tag": "roi",
+        "before": "roi-",
+        "match": "[a-zA-Z0-9]+"
+    },
+    "label": {
+        "tag": "label",
+        "before": "label-",
+        "match": "[a-zA-Z0-9]+"
+    },
+    "from": {
+        "tag": "from",
+        "before": "(?:^|_)from-",
+        "match": "[a-zA-Z0-9]+",
+        "after": ".*xfm"
+    },
+    "to": {
+        "tag": "to",
+        "before": "(?:^|_)to-",
+        "match": "[a-zA-Z0-9]+",
+        "after": ".*xfm"
+    },
+    "mode": {
+        "tag": "mode",
+        "before": "(?:^|_)mode-",
+        "match": "[a-zA-Z0-9]+",
+        "after": ".*xfm"
+    },
+    "hemi": {
+        "tag": "hemi",
+        "before": "hemi-",
+        "match": "L|R"
+    },
+    "res": {
+        "tag": "res",
+        "before": "res-",
+        "match": "[a-zA-Z0-9]+"
+    },
+    "den": {
+        "tag": "den",
+        "before": "den-",
+        "match": "[a-zA-Z0-9]+"
+    },
+    "model": {
+        "tag": "model",
+        "before": "model-",
+        "match": "[a-zA-Z0-9]+"
+    },
+    "subset": {
+        "tag": "subset",
+        "before": "subset-",
+        "match": "[a-zA-Z0-9]+"
+    },
+    "desc": {
+        "tag": "desc",
+        "before": "desc-",
+        "match": "[a-zA-Z0-9]+"
     }
 }

--- a/snakebids/tests/data/custom_config_nonstandard.json
+++ b/snakebids/tests/data/custom_config_nonstandard.json
@@ -1,0 +1,105 @@
+{
+    "name": "bids",
+    "entities": [
+        {
+            "name": "subject",
+            "pattern": "[/\\\\]+sub-([a-zA-Z0-9]+)",
+            "directory": "{subject}"
+        },
+        {
+            "name": "session",
+            "pattern": "[_/\\\\]+ses-([a-zA-Z0-9]+)",
+            "mandatory": false,
+            "directory": "{subject}{session}"
+        },
+        {
+            "name": "task",
+            "pattern": "[_/\\\\]+task-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "acquisition",
+            "pattern": "[_/\\\\]+acq-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "ceagent",
+            "pattern": "[_/\\\\]+ce-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "reconstruction",
+            "pattern": "[_/\\\\]+rec-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "direction",
+            "pattern": "[_/\\\\]+dir-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "run",
+            "pattern": "[_/\\\\]+run-0*(\\d+)",
+            "dtype": "int"
+        },
+        {
+            "name": "proc",
+            "pattern": "[_/\\\\]+proc-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "modality",
+            "pattern": "[_/\\\\]+mod-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "echo",
+            "pattern": "[_/\\\\]+echo-([0-9]+)"
+        },
+        {
+            "name": "flip",
+            "pattern": "[_/\\\\]+flip-([0-9]+)"
+        },
+        {
+            "name": "inv",
+            "pattern": "[_/\\\\]+inv-([0-9]+)"
+        },
+        {
+            "name": "mt",
+            "pattern": "[_/\\\\]+mt-(on|off)"
+        },
+        {
+            "name": "part",
+            "pattern": "[_/\\\\]+part-(imag|mag|phase|real)"
+        },
+        {
+            "name": "recording",
+            "pattern": "[_/\\\\]+recording-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "space",
+            "pattern": "[_/\\\\]+space-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "suffix",
+            "pattern": "[._]*([a-zA-Z0-9]*?)\\.[^/\\\\]+$"
+        },
+        {
+            "name": "scans",
+            "pattern": "(.*\\_scans.tsv)$"
+        },
+        {
+            "name": "fmap",
+            "pattern": "(phasediff|magnitude[1-2]|phase[1-2]|fieldmap|epi)\\.nii"
+        },
+        {
+            "name": "datatype",
+            "pattern": "[/\\\\]+(anat|beh|dwi|eeg|fmap|func|ieeg|meg|perf)[/\\\\]+"
+        },
+        {
+            "name": "foobar",
+            "pattern": "[_/\\\\]+foo-([a-zA-Z0-9]+)"
+        },
+        {
+            "name": "extension",
+            "pattern": "[._]*[a-zA-Z0-9]*?(\\.[^/\\\\]+)$"
+        }
+    ],
+
+    "default_path_patterns": [
+        "sub-{subject}[/ses-{session}]/{datatype<anat>|anat}/sub-{subject}[_ses-{session}][_foo-{foo}]_{suffix<T1w|T2w|T1rho|T1map|T2map|T2star|FLAIR|FLASH|PDmap|PD|PDT2|inplaneT[12]|angio>}{extension<.nii|.nii.gz|.json>|.nii.gz}"
+    ]
+}

--- a/snakebids/tests/strategies.py
+++ b/snakebids/tests/strategies.py
@@ -57,7 +57,7 @@ def input_zip_lists(
     values = {
         entity: draw(
             st.lists(
-                bids_value(entity.pattern if restrict_patterns else ".*"),
+                bids_value(entity.match if restrict_patterns else ".*"),
                 min_size=1,
                 max_size=3,
                 unique=True,

--- a/snakebids/tests/strategies.py
+++ b/snakebids/tests/strategies.py
@@ -137,8 +137,6 @@ def datasets(draw: st.DrawFn, root: Optional[Path] = None):
     ent1 = draw(bids_entity_lists(min_size=2, max_size=3))
     ent2 = copy.copy(ent1)
     ent2.pop()
-    # BUG: snakebids currently doesn't properly parse paths with just suffix
-    assume(ent2 != ["suffix"])
     # BUG: need better controlling if 'datatype' is the only arg
     assume(ent2 != ["datatype"])
     comp1 = draw(bids_components(entities=ent1, restricted_chars=True, root=root))

--- a/snakebids/tests/strategies.py
+++ b/snakebids/tests/strategies.py
@@ -135,14 +135,12 @@ def everything_except(*excluded_types: Type[Any]):
 @st.composite
 def datasets(draw: st.DrawFn, root: Optional[Path] = None):
     ent1 = draw(bids_entity_lists(min_size=2, max_size=3))
-    assume("datatype" not in ent1)
-    # Currently, space and ce cannot coexist because ce is a substr of space (see
-    # snakebids.core.input_generation:_parse_bids_path)
-    assume(not ("space" in ent1 and "ceagent" in ent1))
     ent2 = copy.copy(ent1)
     ent2.pop()
     # BUG: snakebids currently doesn't properly parse paths with just suffix
     assume(ent2 != ["suffix"])
+    # BUG: need better controlling if 'datatype' is the only arg
+    assume(ent2 != ["datatype"])
     comp1 = draw(bids_components(entities=ent1, restricted_chars=True, root=root))
     comp2 = draw(bids_components(entities=ent2, restricted_chars=True, root=root))
     assume(comp1.input_name != comp2.input_name)
@@ -152,9 +150,5 @@ def datasets(draw: st.DrawFn, root: Optional[Path] = None):
 @st.composite
 def datasets_one_comp(draw: st.DrawFn, root: Optional[Path] = None):
     ent1 = draw(bids_entity_lists(min_size=2, max_size=3))
-    assume("datatype" not in ent1)
-    # Currently, space and ce cannot coexist because ce is a substr of space (see
-    # snakebids.core.input_generation:_parse_bids_path)
-    assume(not ("space" in ent1 and "ceagent" in ent1))
     comp1 = draw(bids_components(entities=ent1, restricted_chars=True, root=root))
     return BidsDataset.from_iterable([comp1])

--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -510,7 +510,7 @@ def test_custom_pybids_config(tmpdir: Path):
         pybids_inputs=pybids_inputs,
         bids_dir=tmpdir,
         derivatives=derivatives,
-        pybids_config=(Path(__file__).parent / "data" / "custom_config.json"),
+        pybids_config=Path(__file__).parent / "data" / "custom_config.json",
         use_bids_inputs=True,
     )
     template = BidsDataset(

--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -187,6 +187,22 @@ class TestFilterBools:
             }
         )
     )
+    @example(
+        dataset=BidsDataset(
+            {
+                "1": BidsComponent(
+                    name="1",
+                    path="sub-{subject}/sub-{subject}_{suffix}.foo",
+                    zip_lists={"subject": ["0"], "suffix": ["bar"]},
+                ),
+                "0": BidsComponent(
+                    name="0",
+                    path="{suffix}.foo",
+                    zip_lists={"suffix": ["bar"]},
+                ),
+            }
+        )
+    )
     @settings(
         deadline=800,
         suppress_health_check=[

--- a/snakebids/utils/utils.py
+++ b/snakebids/utils/utils.py
@@ -217,6 +217,15 @@ def get_match_search_func(
     return inner
 
 
+class BidsParseError(Exception):
+    """Exception raised for errors encountered in the parsing of Bids paths"""
+
+    def __init__(self, path: str, entity: BidsEntity):
+        self.path = path
+        self.entity = entity
+        super().__init__(path, entity)
+
+
 # pylint: disable=too-few-public-methods
 class _Documented(Protocol):
     __doc__: str

--- a/snakebids/utils/utils.py
+++ b/snakebids/utils/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools as ft
 import importlib.resources
 import json
+import re
 from typing import Any, Callable, Dict, Iterable, TypeVar
 
 import attrs
@@ -76,8 +77,8 @@ class BidsEntity:
         )
 
     @property
-    def pattern(self):
-        """Get regex of acceptable patterns
+    def match(self):
+        """Get regex of acceptable value matches
 
         If no pattern is associated with the entity, the default pattern is a word with
         letters and numbers
@@ -88,10 +89,52 @@ class BidsEntity:
         """
         tags = read_bids_tags()
         return (
-            tags[self.entity]["pattern"]
-            if self.entity in tags and "pattern" in tags[self.entity]
+            tags[self.entity]["match"]
+            if self.entity in tags and "match" in tags[self.entity]
             else "[a-zA-Z0-9]+"
         )
+
+    @property
+    def before(self):
+        """regex str to search before value in paths
+
+        Returns
+        -------
+        str
+        """
+        tags = read_bids_tags()
+        return (
+            tags[self.entity]["before"]
+            if self.entity in tags and "before" in tags[self.entity]
+            else f"{self.tag}-"
+        )
+
+    @property
+    def after(self):
+        """regex str to search after value in paths
+
+        Returns
+        -------
+        str
+        """
+        tags = read_bids_tags()
+        return (
+            tags[self.entity]["after"]
+            if self.entity in tags and "after" in tags[self.entity]
+            else ""
+        )
+
+    @property
+    def regex(self):
+        """Complete pattern to match when searching in paths
+
+        Contains three capture groups, the first corresponding to "before", the second
+        to "value", and the third to "after"
+        Returns
+        -------
+        str
+        """
+        return re.compile(f"({self.before})({self.match})({self.after})")
 
     @property
     def wildcard(self):


### PR DESCRIPTION
This corrects some of the mistakes made by the previous parser: mistakes caused by overlapping entity names (space and ce), inability to have "datatype" or "extension" as entities, and paths with just suffixes.

Now use the expanded bids_tags.json file to specifically match every tag. If a tag is given that isn't found in bids_tags.json, fall back to the previous `tag-[a-zA-Z0-1]` syntax.

Implementing this ended up being a bit more challenging than I thought. I was hoping I could just use the pybids entity info already available, but we need to *replace* the matched value with a wildcard, and there's no way of doing this without riskily trying to parse the pattern from pybids. Since I'm not willing to do that, we need to encode the missing information in our own `bids_tags.json` file.

I decided to use a "before", "match", "after" syntax in order to reduce data duplication (as opposed to having "pattern" with everything and "match" with just the core bit, as the core bit would appear in both "match" and "pattern"). I use "match" as the name instead of "pattern" so that it doesn't overlap with "pattern" in the pybids config file. I'm hoping that we can push this back to pybids as an update to their syntax, and this will keep it backwards-compatible.

Until then, we will unfortunately need to keep this list maintained. Pybids has previously updated their list of entities on patch releases, so we'll have to check in every once in a while to see if anythings changed.

Note that I snuck in a few type related and small refactoring changes. They're grouped together on their own commit.

Resolves https://github.com/akhanf/snakebids/issues/192

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [x] Changes pass the unit tests
- [x] I have included necessary documentation or comments (as necessary)
- [x] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.