### PR TITLE
[FIX] change error message when no input found

### DIFF
--- a/snakebids/core/input_generation.py
+++ b/snakebids/core/input_generation.py
@@ -636,7 +636,7 @@ def _get_lists_from_bids(
 
         # now, check to see if unique
         if len(paths) == 0:
-            _logger.warning("No input files found for %s", input_name)
+            _logger.warning("No input file found for %s", input_name)
             continue
         try:
             path = itx.one(paths)

--- a/snakebids/core/input_generation.py
+++ b/snakebids/core/input_generation.py
@@ -636,7 +636,7 @@ def _get_lists_from_bids(
 
         # now, check to see if unique
         if len(paths) == 0:
-            _logger.warning("No images found for %s", input_name)
+            _logger.warning("No input files found for %s", input_name)
             continue
         try:
             path = itx.one(paths)


### PR DESCRIPTION
## Proposed changes

This is a minor change in an error message that says "no image found" even if the user does not use images as inputs.

It would now read: 

```python
_logger.warning("No input file found for %s", input_name)
```

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [ ] Changes have been tested to ensure that fix is effective or that a feature works.
- [ ] Changes pass the unit tests
- [ ] I have included necessary documentation or comments (as necessary)
- [ ] Any dependent changes have been merged and published

## Notes

All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.