### PR TITLE
Ensure bids() is called with identifying entities

### DIFF
--- a/snakebids/core/construct_bids.py
+++ b/snakebids/core/construct_bids.py
@@ -130,7 +130,17 @@ def bids(
     """
     if not any([entities, suffix, subject, session]):
         raise ValueError(
-            "At least one of subject, session, suffix, or an entity must be supplied"
+            "At least one of subject, session, suffix, or an entity must be supplied.\n"
+            "\tGot only: "
+            + " and ".join(
+                filter(
+                    None,
+                    (
+                        f"datatype='{datatype}'" if datatype else None,
+                        f"prefix='{prefix}'" if prefix else None,
+                    ),
+                )
+            )
         )
 
     # replace underscores in keys (needed so that users can use reserved

--- a/snakebids/core/construct_bids.py
+++ b/snakebids/core/construct_bids.py
@@ -1,18 +1,19 @@
 """Utilities for converting Snakemake apps to BIDS apps."""
+from __future__ import annotations
 
 from collections import OrderedDict
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
 
 # pylint: disable=too-many-arguments
 def bids(
-    root: Union[str, Path] = None,
-    datatype: str = None,
-    prefix: str = None,
-    suffix: str = None,
-    subject: str = None,
-    session: str = None,
+    root: str | Path | None = None,
+    datatype: str | None = None,
+    prefix: str | None = None,
+    suffix: str | None = None,
+    subject: str | None = None,
+    session: str | None = None,
     include_subject_dir: bool = True,
     include_session_dir: bool = True,
     **entities: str,
@@ -127,7 +128,10 @@ def bids(
     * Some code adapted from mne-bids, specifically
       https://mne.tools/mne-bids/stable/_modules/mne_bids/utils.html
     """
-    # BUG: Datatype as the only arg is ill-defined, but no error is raised
+    if not any([entities, suffix, subject, session]):
+        raise ValueError(
+            "At least one of subject, session, suffix, or an entity must be supplied"
+        )
 
     # replace underscores in keys (needed so that users can use reserved
     # keywords by appending a _)

--- a/snakebids/core/construct_bids.py
+++ b/snakebids/core/construct_bids.py
@@ -74,18 +74,16 @@ def bids(
                 suffix='T1w.nii.gz'
             )
 
-    Note that here we are not actually using "functions as inputs" in
-    snakemake, which would require a function definition with wildcards as
-    the argument, and restrict to input/params, but bids() is being used
-    simply to return a string.
+    Note that here we are not actually using "functions as inputs" in snakemake, which
+    would require a function definition with wildcards as the argument, and restrict to
+    input/params, but bids() is being used simply to return a string.
 
-    Also note that space, desc and suffix are NOT wildcards here, only
-    {subject} is. This makes it easy to combine wildcards and non-wildcards
-    with bids-like naming.
+    Also note that space, desc and suffix are NOT wildcards here, only {subject} is.
+    This makes it easy to combine wildcards and non-wildcards with bids-like naming.
 
-    However, you can still use bids() in a lambda function. This is
-    especially useful if your wildcards are named the same as bids entities
-    (e.g. {subject}, {session}, {task} etc..)::
+    However, you can still use bids() in a lambda function. This is especially useful if
+    your wildcards are named the same as bids entities (e.g. {subject}, {session},
+    {task} etc..)::
 
         rule proc_img:
             input: lambda wildcards: bids(**wildcards,suffix='T1w.nii.gz')
@@ -96,8 +94,8 @@ def bids(
                 suffix='T1w.nii.gz'
             )
 
-    Or another example where you may have many bids-like wildcards used in
-    your workflow::
+    Or another example where you may have many bids-like wildcards used in your
+    workflow::
 
         rule denoise_func:
             input: lambda wildcards: bids(**wildcards, suffix='bold.nii.gz')
@@ -110,25 +108,26 @@ def bids(
                 suffix='bold.nii.gz'
             )
 
-    In this example, all the wildcards will be determined from the output
-    and passed on to bids() for inputs. The output filename will have a
-    'desc-denoise' flag added to it.
+    In this example, all the wildcards will be determined from the output and passed on
+    to bids() for inputs. The output filename will have a 'desc-denoise' flag added to
+    it.
 
-    Also note that even if you supply entities in a different order, the
-    entities will be ordered based on the OrderedDict defined here.
-    If entities not known are provided, they will be just be placed
-    at the end (before the suffix), in the order you provide them in.
+    Also note that even if you supply entities in a different order, the entities will
+    be ordered based on the OrderedDict defined here. If entities not known are
+    provided, they will be just be placed at the end (before the suffix), in the order
+    you provide them in.
 
     Notes
     -----
 
-    * For maximum flexibility all arguments are optional (if none are
-      specified, will return empty string)
+    * For maximum flexibility all arguments are optional (if none are specified, will
+      return empty string). Note that datatype and prefix may not be used in isolation,
+      but must be given with another entity.
 
     * Some code adapted from mne-bids, specifically
       https://mne.tools/mne-bids/stable/_modules/mne_bids/utils.html
     """
-    if not any([entities, suffix, subject, session]):
+    if not any([entities, suffix, subject, session]) and any([datatype, prefix]):
         raise ValueError(
             "At least one of subject, session, suffix, or an entity must be supplied.\n"
             "\tGot only: "

--- a/snakebids/core/construct_bids.py
+++ b/snakebids/core/construct_bids.py
@@ -8,12 +8,12 @@ from typing import Optional
 
 # pylint: disable=too-many-arguments
 def bids(
-    root: str | Path | None = None,
-    datatype: str | None = None,
-    prefix: str | None = None,
-    suffix: str | None = None,
-    subject: str | None = None,
-    session: str | None = None,
+    root: Optional[str | Path] = None,
+    datatype: Optional[str] = None,
+    prefix: Optional[str] = None,
+    suffix: Optional[str] = None,
+    subject: Optional[str] = None,
+    session: Optional[str] = None,
     include_subject_dir: bool = True,
     include_session_dir: bool = True,
     **entities: str,

--- a/snakebids/tests/test_bids.py
+++ b/snakebids/tests/test_bids.py
@@ -16,6 +16,10 @@ def test_bids_subj():
     )
 
 
+def test_bids_with_no_args_gives_empty_path():
+    assert bids() == ""
+
+
 @pytest.mark.parametrize(
     ("args"),
     [

--- a/snakebids/tests/test_bids.py
+++ b/snakebids/tests/test_bids.py
@@ -1,6 +1,8 @@
-from __future__ import absolute_import
+from __future__ import annotations
 
 from pathlib import Path
+
+import pytest
 
 from snakebids.core.construct_bids import bids
 
@@ -12,3 +14,16 @@ def test_bids_subj():
     assert bids(root=Path("bids").resolve(), subject="001", suffix="T1w.nii.gz") == (
         str(Path.cwd() / "bids/sub-001/sub-001_T1w.nii.gz")
     )
+
+
+@pytest.mark.parametrize(
+    ("args"),
+    [
+        {"datatype": "foo"},
+        {"prefix": "foo"},
+        {"datatype": "foo", "prefix": "foo"},
+    ],
+)
+def test_missing_essential_entities_gives_error(args: dict[str, str]):
+    with pytest.raises(ValueError):
+        bids(**args)

--- a/snakebids/tests/test_datasets.py
+++ b/snakebids/tests/test_datasets.py
@@ -64,7 +64,12 @@ class TestBidsComponentValidation:
 
     @given(sb_st.input_zip_lists().filter(lambda v: len(v) > 1))
     def test_path_cannot_have_missing_entities(self, zip_lists: Dict[str, List[str]]):
-        path = get_bids_path(sb_it.drop(1, zip_lists))
+        # Snakebids strategies won't return a zip_list with just datatype, but now that
+        # we've dropped an entity we need to check again
+        path_entities = sb_it.drop(1, zip_lists)
+        assume(set(path_entities) - {"datatype"})
+
+        path = get_bids_path(path_entities)
         with pytest.raises(ValueError) as err:
             BidsComponent("foo", path, zip_lists)
         assert (

--- a/snakebids/utils/sb_itertools.py
+++ b/snakebids/utils/sb_itertools.py
@@ -30,6 +30,15 @@ def unpack(iterable: Iterable[T], default: Sequence[T]) -> Iterable[T]:
 
 # pylint: disable=invalid-name
 def drop(n: int, iterable: Iterable[T]) -> Iterable[T]:
-    first, second = it.tee(iterable, 2)
-    keep = itx.ilen(first) - n
-    return itx.take(max(0, keep), second)
+    """Returns all items of an iterable except the first *n* as a list
+
+    >>> drop(7, range(10))
+    [7, 8, 9]
+
+    If there are fewer than *n* items in the iterable, none of them are returned
+
+    >>> drop(8, range(5))
+    []
+    """
+    _list = list(iterable)
+    return list(it.islice(_list, n, len(_list)))


### PR DESCRIPTION
Calls to bids with just datatype and/or prefix are indistinguishable from calls to bids with just suffix. Pybids would parse these paths as having suffixes. Thus, we prevent this types of calls altogether

Resolves #193



## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [x] Changes pass the unit tests
- [x] I have included necessary documentation or comments (as necessary)
- [x] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.