### PR TITLE
Add deprecation warnings to `BidsDataset` properties slated for change

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -234,6 +234,24 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "deprecation"
+version = "2.1.0"
+description = "A library to handle automated deprecations"
+category = "main"
+optional = false
+python-versions = "*"
+develop = false
+
+[package.dependencies]
+packaging = "*"
+
+[package.source]
+type = "git"
+url = "https://github.com/pvandyken/deprecation.git"
+reference = "updates"
+resolved_reference = "8309c44112f349df9c38cbbfea6aed73f99ff66c"
+
+[[package]]
 name = "dill"
 version = "0.3.6"
 description = "serialize all of python"
@@ -1701,7 +1719,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.12"
-content-hash = "51d46ab2413d0a1cdb6b3581e8f1e7d67a6dacd302bfc2510f334570b194df59"
+content-hash = "ce7ac5231dbff1af17bd4bf8f0679443ce94377a84b2e0e7b8e4e4c491d47ccd"
 
 [metadata.files]
 appdirs = [
@@ -1918,6 +1936,7 @@ datrie = [
     {file = "datrie-0.8.2-pp373-pypy36_pp73-win32.whl", hash = "sha256:89ff3d41df4f899387aa07b4b066f5da36e3a10b67b8aeae631c950502ff4503"},
     {file = "datrie-0.8.2.tar.gz", hash = "sha256:525b08f638d5cf6115df6ccd818e5a01298cd230b2dac91c8ff2e6499d18765d"},
 ]
+deprecation = []
 dill = [
     {file = "dill-0.3.6-py3-none-any.whl", hash = "sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0"},
     {file = "dill-0.3.6.tar.gz", hash = "sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ attrs = ">=21.2.0,<23"
 boutiques = "^0.5.25"
 more-itertools = ">=8,<10"
 cached-property = "^1.5.2"
+deprecation = { git = "https://github.com/pvandyken/deprecation.git", rev="8309c44" }
 
 #  Below are non-direct dependencies (i.e. dependencies of other depenencies)
 #  specified to ensure a version with a pre-built wheel is installed depending

--- a/snakebids/core/datasets.py
+++ b/snakebids/core/datasets.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools as it
 import operator as op
+import warnings
 from collections import UserDict
 from string import Formatter
 from typing import TYPE_CHECKING, Any, Iterable, Optional, Union, cast
@@ -289,9 +290,7 @@ class BidsDataset(_BidsComponentsType):
         return [
             *{
                 *it.chain.from_iterable(
-                    input_list["subject"]
-                    for input_list in self.entities.values()
-                    if "subject" in input_list
+                    component.entities.get("subject", []) for component in self.values()
                 )
             }
         ]
@@ -302,9 +301,7 @@ class BidsDataset(_BidsComponentsType):
         return [
             *{
                 *it.chain.from_iterable(
-                    input_list["session"]
-                    for input_list in self.entities.values()
-                    if "session" in input_list
+                    component.entities.get("session", []) for component in self.values()
                 )
             }
         ]
@@ -334,15 +331,17 @@ class BidsDataset(_BidsComponentsType):
         -------
         BidsDatasetDict
         """
-        return BidsDatasetDict(
-            input_path=self.input_path,
-            input_lists=self.entities,
-            input_wildcards=self.input_wildcards,
-            input_zip_lists=self.input_zip_lists,
-            subjects=self.subjects,
-            sessions=self.sessions,
-            subj_wildcards=self.subj_wildcards,
-        )
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            return BidsDatasetDict(
+                input_path=self.input_path,
+                input_lists=self.entities,
+                input_wildcards=self.input_wildcards,
+                input_zip_lists=self.input_zip_lists,
+                subjects=self.subjects,
+                sessions=self.sessions,
+                subj_wildcards=self.subj_wildcards,
+            )
 
     @classmethod
     def from_iterable(cls, iterable: Iterable[BidsComponent]):

--- a/snakebids/core/datasets.py
+++ b/snakebids/core/datasets.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Optional, Union, cast
 import attr
 import more_itertools as itx
 from cached_property import cached_property
+from deprecation import deprecated
 from typing_extensions import TypedDict
 
 import snakebids.utils.sb_itertools as sb_it
@@ -200,6 +201,15 @@ class BidsDataset(_BidsComponentsType):
         )
 
     @cached_property
+    @deprecated(
+        details="""
+        The behaviour of path will change in an upcoming release, where it will refer
+        instead to the root path of the dataset. Please access component paths using
+        :attr:`Dataset[\\<component_name\\>].path <BidsComponent.path>`
+        """,
+        deprecated_in="0.8.0",
+        admonition="warning",
+    )
     def path(self):
         """Dict mapping :class:`BidsComponents <snakebids.BidsComponent>` names to \
         their ``paths``.
@@ -211,6 +221,16 @@ class BidsDataset(_BidsComponentsType):
         return self.path
 
     @cached_property
+    @deprecated(
+        details="""
+        The behaviour of zip_lists will change in an upcoming release, where it will
+        refer instead to the consensus of entity groups across all components in the
+        dataset. Please access component zip_lists using
+        :attr:`Dataset[\\<component_name\\>].zip_lists <BidsComponent.zip_lists>`
+        """,
+        deprecated_in="0.8.0",
+        admonition="warning",
+    )
     def zip_lists(self):
         """Dict mapping :class:`BidsComponents <snakebids.BidsComponent>` names to \
         their ``zip_lists``
@@ -222,6 +242,16 @@ class BidsDataset(_BidsComponentsType):
         return self.zip_lists
 
     @cached_property
+    @deprecated(
+        details="""
+        The behaviour of entities will change in the 1.0 release, where it will refer
+        instead to the union of all entity-values across all components in the dataset.
+        Please access component entity lists using
+        :attr:`Dataset[\\<component_name\\>].entities <BidsComponent.entities>`
+        """,
+        deprecated_in="0.8.0",
+        admonition="warning",
+    )
     def entities(self):
         """Dict mapping :class:`BidsComponents <snakebids.BidsComponent>` names to \
         to their :attr:`entities <snakebids.BidsComponent.entities>`
@@ -233,6 +263,16 @@ class BidsDataset(_BidsComponentsType):
         return self.entities
 
     @cached_property
+    @deprecated(
+        details="""
+        The behaviour of wildcards will change in an upcoming release, where it will
+        refer instead to the union of all entity-wildcard mappings across all components
+        in the dataset. Please access component wildcards using
+        :attr:`Dataset[\\<component_name\\>].wildcards <BidsComponent.wildcards>`
+        """,
+        deprecated_in="0.8.0",
+        admonition="warning",
+    )
     def wildcards(self):
         """Dict mapping :class:`BidsComponents <snakebids.BidsComponent>` names to \
         their :attr:`wildcards <snakebids.BidsComponent.wildcards>`

--- a/snakebids/project_template/{{cookiecutter.app_name}}/workflow/Snakefile
+++ b/snakebids/project_template/{{cookiecutter.app_name}}/workflow/Snakefile
@@ -26,14 +26,14 @@ wildcard_constraints:  **snakebids.get_wildcard_constraints(config['pybids_input
 
 
 rule smooth:
-    input: inputs.path['bold']
+    input: inputs['bold'].path
     output:
         bids(
             root=config['root'],
             datatype='func',
             desc='smooth{fwhm}mm',
             suffix='bold.nii.gz',
-            **inputs.wildcards['bold']
+            **inputs['bold'].wildcards
         )
     container: config['singularity']['fsl']
     log:
@@ -41,7 +41,7 @@ rule smooth:
             root='logs',
             suffix='smooth.log',
             fwhm='{fwhm}',
-            **inputs.wildcards['bold']
+            **inputs['bold'].wildcards
         )
     params: sigma = lambda wildcards: f'{float(wildcards.fwhm)/2.355:0.2f}'
     shell: 'fslmaths {input} -s {params.sigma} {output}'
@@ -56,6 +56,6 @@ rule all:
                 allow_missing=True,
             ),
             zip,
-            **inputs.zip_lists['bold']
+            **inputs['bold'].zip_lists
         )
     default_target: True

--- a/snakebids/tests/test_datasets.py
+++ b/snakebids/tests/test_datasets.py
@@ -1,5 +1,6 @@
 import copy
 import itertools as it
+import warnings
 from typing import Any, Dict, List
 
 import more_itertools as itx
@@ -31,11 +32,13 @@ class TestBidsComponentAliases:
 
     @given(sb_st.bids_components())
     def test_bids_dataset_aliases_are_correctly_set(self, component: BidsComponent):
-        dataset = BidsDataset.from_iterable([component])
-        assert dataset.input_path == dataset.path
-        assert dataset.input_zip_lists == dataset.zip_lists
-        assert dataset.input_lists == dataset.input_lists
-        assert dataset.input_wildcards == dataset.wildcards
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            dataset = BidsDataset.from_iterable([component])
+            assert dataset.input_path == dataset.path
+            assert dataset.input_zip_lists == dataset.zip_lists
+            assert dataset.input_lists == dataset.input_lists
+            assert dataset.input_wildcards == dataset.wildcards
 
 
 class TestBidsComponentValidation:

--- a/snakebids/tests/test_datasets.py
+++ b/snakebids/tests/test_datasets.py
@@ -37,7 +37,7 @@ class TestBidsComponentAliases:
             dataset = BidsDataset.from_iterable([component])
             assert dataset.input_path == dataset.path
             assert dataset.input_zip_lists == dataset.zip_lists
-            assert dataset.input_lists == dataset.input_lists
+            assert dataset.input_lists == dataset.entities
             assert dataset.input_wildcards == dataset.wildcards
 
 

--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -58,7 +58,6 @@ class TestFilterBools:
 
     def disambiguate_components(self, dataset: BidsDataset):
         assert len(dataset) == 2
-        dataset.zip_lists
         comp1, comp2 = dataset.values()
         return sorted([comp1, comp2], key=lambda comp: len(comp.entities.keys()))
 
@@ -271,9 +270,7 @@ class TestAbsentConfigEntries:
             pybids_config=str(Path(__file__).parent / "data" / "custom_config.json"),
             use_bids_inputs=True,
         )
-        template = BidsDataset(
-            {"t1": BidsComponent("t1", config.input_path["t1"], zip_list)}
-        )
+        template = BidsDataset({"t1": BidsComponent("t1", config["t1"].path, zip_list)})
         # Order of the subjects is not deterministic
         assert template == config
         assert config.subj_wildcards == {"subject": "{subject}"}
@@ -297,7 +294,7 @@ class TestAbsentConfigEntries:
             pybids_config=str(Path(__file__).parent / "data" / "custom_config.json"),
             use_bids_inputs=True,
         )
-        template = BidsDataset({"t1": BidsComponent("t1", config.input_path["t1"], {})})
+        template = BidsDataset({"t1": BidsComponent("t1", config["t1"].path, {})})
         assert template == config
         assert config.subj_wildcards == {"subject": "{subject}"}
 
@@ -573,7 +570,7 @@ def test_custom_pybids_config(tmpdir: Path):
         }
     )
     assert template == result
-    assert result.input_wildcards == {"t1": {"foo": "{foo}", "subject": "{subject}"}}
+    assert result["t1"].wildcards == {"foo": "{foo}", "subject": "{subject}"}
     # Order of the subjects is not deterministic
     assert result.subj_wildcards == {"subject": "{subject}"}
 
@@ -647,7 +644,7 @@ def test_t1w():
         {
             "t1": BidsComponent(
                 "t1",
-                result.input_path["t1"],
+                result["t1"].path,
                 {"acq": ["mprage", "mprage"], "subject": ["001", "002"]},
             )
         }
@@ -678,14 +675,16 @@ def test_t1w():
         participant_label="001",
         use_bids_inputs=True,
     )
-    assert result.entities == {
-        "scan": {"acq": ["mprage"], "subject": ["001"], "suffix": ["T1w"]}
+    assert result["scan"].entities == {
+        "acq": ["mprage"],
+        "subject": ["001"],
+        "suffix": ["T1w"],
     }
     template = BidsDataset(
         {
             "scan": BidsComponent(
                 "scan",
-                result.input_path["scan"],
+                result["scan"].path,
                 {
                     "acq": [
                         "mprage",
@@ -751,15 +750,13 @@ def test_t1w():
             {
                 "t1": BidsComponent(
                     "t1",
-                    result.input_path["t1"],
+                    result["t1"].path,
                     {
                         "acq": ["mprage", "mprage"],
                         "subject": ["001", "002"],
                     },
                 ),
-                "t2": BidsComponent(
-                    "t2", result.input_path["t2"], {"subject": ["002"]}
-                ),
+                "t2": BidsComponent("t2", result["t2"].path, {"subject": ["002"]}),
             }
         )
         # Order of the subjects is not deterministic

--- a/snakebids/utils/utils.py
+++ b/snakebids/utils/utils.py
@@ -232,7 +232,12 @@ class _Documented(Protocol):
     __doc__: str
 
 
-def property_alias(prop: _Documented, label: str | None = None, ref: str | None = None):
+def property_alias(
+    prop: _Documented,
+    label: str | None = None,
+    ref: str | None = None,
+    copy_extended_docstring: bool = False,
+):
     """Set property as an alias for another property
 
     Copies the docstring from the aliased property to the alias
@@ -241,6 +246,12 @@ def property_alias(prop: _Documented, label: str | None = None, ref: str | None 
     ----------
     prop : property
         Property to alias
+    label
+        Text to use in link to aliased property
+    ref
+        Name of the property to alias
+    copy_extended_docstring
+        If True, copies over the entire docstring, in addition to the summary line
 
     Returns
     -------
@@ -254,7 +265,10 @@ def property_alias(prop: _Documented, label: str | None = None, ref: str | None 
         else:
             link = f":attr:`{ref}`" if ref else None
         labeltxt = f"Alias of {link}\n\n" if link else ""
-        alias.__doc__ = f"{labeltxt}{prop.__doc__}"
+        if copy_extended_docstring:
+            alias.__doc__ = f"{labeltxt}{prop.__doc__}"
+        else:
+            alias.__doc__ = f"{labeltxt}{prop.__doc__.splitlines()[0]}"
         return alias
 
     return inner

--- a/typings/deprecation.pyi
+++ b/typings/deprecation.pyi
@@ -1,0 +1,27 @@
+from datetime import date
+from typing import Callable, Generic, ParamSpec, TypeVar
+
+P = ParamSpec("P")
+T = TypeVar("T", bound=Callable)
+
+class DeprecatedWarning(DeprecationWarning, Generic[T]):
+    def __init__(
+        self,
+        function: T,
+        deprecated_in: str,
+        removed_in: str | date | None,
+        details: str = ...,
+    ): ...
+    def __str__(self) -> str: ...
+
+class UnsupportedWarning(DeprecatedWarning):
+    def __str__(self) -> str: ...
+
+def deprecated(
+    deprecated_in: str | None = ...,
+    removed_in: str | date | None = ...,
+    current_version: str | None = ...,
+    details: str | None = ...,
+    admonition: str | None = ...,
+) -> Callable[[T], T]: ...
+def fail_if_not_removed(method: T) -> T: ...


### PR DESCRIPTION
Resolves #237.

This PR does not yet include any changes to the docs, as the rewrite will be a bit complicated, and I may want to incorporate the pretty printing #197 into it to ease the explanations.

I'm using the [deprecation](https://github.com/briancurtin/deprecation) library, or rather, a custom fork of it. I wanted the deprecations to be displayed prominently in the docs, and the default sphinx directive just displays it as vanilla text without any box or anything. So I modified deprecation to allow me to nest the deprecation message in a warning box. I've raised an [issue](https://github.com/briancurtin/deprecation/issues/62) there about incorporating this into the main repository.

One other note: by default, Python actually doesn't display `DeprecationWarnings`. This is to prevent end-users of an app from seeing warnings that don't pertain to them. For example, if Hippunfold upgrades `snakebids` to this PR but doesn't make the syntax changes in their workflow, there's no reason for their users to see all the resulting warning messages.

In order to the warnings they have to be enabled. Test suites do this by default. You can also call your script as `python -Wdefault`.

The problem is I don't know that snakemake users are typically using test suites on their workflows, and would probably never think to use the `-W` flag. So probably no one will ever see the warnings.

So we can just rely on the docs and changelogs to get people to migrate. There's also a separate `FutureWarning` that is always displayed, but then end users of the app will also see it.

Any ideas or thoughts on this are appreciated.