### PR TITLE
BIDS validation

### DIFF
--- a/docs/bids_app/workflow.rst
+++ b/docs/bids_app/workflow.rst
@@ -14,10 +14,10 @@ To get access to these additions, the base Snakefile for a snakebids workflow sh
     inputs = snakebids.generate_inputs(
         bids_dir=config["bids_dir"],
         pybids_inputs=config["pybids_inputs"],
+        skip_bids_validation=config["skip_bids_validation"],
         derivatives=config.get("derivatives", None),
         participant_label=config.get("participant_label", None),
         exclude_participant_label=config.get("exclude_participant_label", None)
-
     )
 
     #this adds constraints to the bids naming

--- a/docs/running_snakebids/overview.md
+++ b/docs/running_snakebids/overview.md
@@ -19,6 +19,8 @@ Indexing of large datasets can be a time-consuming process. Snakebids, through `
 1. Uncomment the lines in `snakebids.yml` containing `pybids_db_dir` and `pybids_db_reset`.
 1. The variables can be updated directly in this file or through the CLI by using `-pybidsdb-dir {dir}` to specify the database path and `--reset-db` to indicate that the database should be updated. _Note: CLI arguments take precendence if both CLI and config variables are set._
 
+Input BIDS datasets are also validated via the bids-validator. By default, this feature uses the command-line (node.js) version of the [validator](https://www.npmjs.com/package/bids-validator). If this is not found to be installed on the system, the `pybids` version of validation will be performed instead. To opt-out validation, one can invoke `--skip-bids-validation`. 
+
 Workflow mode
 =============
 

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -171,6 +171,8 @@ class SnakeBidsApp:
             self.config["pybids_db_dir"] = args.pybidsdb_dir
         self.config["pybids_db_reset"] = args.reset_db
 
+        self.config["skip_bids_validation"] = args.skip_validation
+
         update_config(self.config, args)
 
         # First, handle outputs in snakebids_root or results folder

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -171,7 +171,7 @@ class SnakeBidsApp:
             self.config["pybids_db_dir"] = args.pybidsdb_dir
         self.config["pybids_db_reset"] = args.reset_db
 
-        self.config["skip_bids_validation"] = args.skip_validation
+        self.config["skip_bids_validation"] = args.skip_bids_validation
 
         update_config(self.config, args)
 

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -20,6 +20,7 @@ from snakebids.cli import (
     parse_snakebids_args,
 )
 from snakebids.exceptions import ConfigError, RunError
+from snakebids.plugins.validation import bids_validate
 from snakebids.utils.output import (
     prepare_bidsapp_output,
     write_config_file,
@@ -170,8 +171,6 @@ class SnakeBidsApp:
         if args.pybidsdb_dir:
             self.config["pybids_db_dir"] = args.pybidsdb_dir
         self.config["pybids_db_reset"] = args.reset_db
-
-        self.config["skip_bids_validation"] = args.skip_bids_validation
 
         update_config(self.config, args)
 

--- a/snakebids/cli.py
+++ b/snakebids/cli.py
@@ -55,20 +55,25 @@ class SnakebidsArgs:
         Directory to place outputs
     pybidsdb_dir : Path
         Directory to place pybids database
+    reset_db : bool
+        Update the pybids database
     snakemake_args : list of strings
         Arguments to pass on to Snakemake
     args_dict : Dict[str, Any]
         Contains all the snakebids specific args. Meant to contain custom user args
         defined in config, as well as dynamic --filter-xx and --wildcard-xx args.
         These will eventually be printed in the new config.
+    skip_validation : bool
+        Skip bids validation of input dataset
     """
 
     force: bool
     outputdir: Path = attr.ib(converter=lambda p: Path(p).resolve())
-    snakemake_args: List[str]
-    args_dict: Dict[str, Any]
     pybidsdb_dir: Optional[Path] = None
     reset_db: bool = False
+    snakemake_args: List[str]
+    args_dict: Dict[str, Any]
+    skip_validation: bool = False
 
 
 def create_parser(include_snakemake=False):
@@ -139,6 +144,13 @@ def create_parser(include_snakemake=False):
         "--force_output",
         action="store_true",
         help="Force output in a new directory that already has contents",
+    )
+
+    standard_group.add_argument(
+        "--skip-validation",
+        "--skip_validation",
+        action="store_true",
+        help=("Skip BIDS validation of input dataset")
     )
 
     standard_group.add_argument(

--- a/snakebids/cli.py
+++ b/snakebids/cli.py
@@ -69,10 +69,10 @@ class SnakebidsArgs:
 
     force: bool
     outputdir: Path = attr.ib(converter=lambda p: Path(p).resolve())
-    pybidsdb_dir: Optional[Path] = None
-    reset_db: bool = False
     snakemake_args: List[str]
     args_dict: Dict[str, Any]
+    pybidsdb_dir: Optional[Path] = None
+    reset_db: bool = False
     skip_validation: bool = False
 
 

--- a/snakebids/cli.py
+++ b/snakebids/cli.py
@@ -150,7 +150,7 @@ def create_parser(include_snakemake=False):
         "--skip-bids-validation",
         "--skip_bids-validation",
         action="store_true",
-        help=("Skip bids validation of input dataset")
+        help=("Skip bids validation of input dataset"),
     )
 
     standard_group.add_argument(

--- a/snakebids/cli.py
+++ b/snakebids/cli.py
@@ -150,7 +150,7 @@ def create_parser(include_snakemake=False):
         "--skip-validation",
         "--skip_validation",
         action="store_true",
-        help=("Skip BIDS validation of input dataset")
+        help=("Skip bids validation of input dataset")
     )
 
     standard_group.add_argument(
@@ -283,6 +283,7 @@ def parse_snakebids_args(parser: argparse.ArgumentParser):
             else Path(all_args[0].pybidsdb_dir).resolve()
         ),
         reset_db=all_args[0].reset_db,
+        skip_bids_validation=all_args[0].skip_validation,
     )
 
 

--- a/snakebids/cli.py
+++ b/snakebids/cli.py
@@ -63,7 +63,7 @@ class SnakebidsArgs:
         Contains all the snakebids specific args. Meant to contain custom user args
         defined in config, as well as dynamic --filter-xx and --wildcard-xx args.
         These will eventually be printed in the new config.
-    skip_validation : bool
+    skip_bids_validation : bool
         Skip bids validation of input dataset
     """
 
@@ -73,7 +73,7 @@ class SnakebidsArgs:
     args_dict: Dict[str, Any]
     pybidsdb_dir: Optional[Path] = None
     reset_db: bool = False
-    skip_validation: bool = False
+    skip_bids_validation: bool = False
 
 
 def create_parser(include_snakemake=False):
@@ -147,8 +147,8 @@ def create_parser(include_snakemake=False):
     )
 
     standard_group.add_argument(
-        "--skip-validation",
-        "--skip_validation",
+        "--skip-bids-validation",
+        "--skip_bids-validation",
         action="store_true",
         help=("Skip bids validation of input dataset")
     )
@@ -283,7 +283,7 @@ def parse_snakebids_args(parser: argparse.ArgumentParser):
             else Path(all_args[0].pybidsdb_dir).resolve()
         ),
         reset_db=all_args[0].reset_db,
-        skip_bids_validation=all_args[0].skip_validation,
+        skip_bids_validation=all_args[0].skip_bids_validation,
     )
 
 

--- a/snakebids/core/input_generation.py
+++ b/snakebids/core/input_generation.py
@@ -135,10 +135,10 @@ def generate_inputs(
         be specified if participant_label is specified
 
     skip_bids_validation : bool, optional
-        If True, will not perform validation of the input dataset. Otherwise, 
+        If True, will not perform validation of the input dataset. Otherwise,
         validation is first attempted by performing a system call to `bids-validator`
-        (e.g. node version), which is has more comprehensive coverage, before falling 
-        back on the python version of the validator. 
+        (e.g. node version), which is has more comprehensive coverage, before falling
+        back on the python version of the validator.
 
     use_bids_inputs : bool, optional
         If True, opts in to the new :class:`BidsDataset` output, otherwise returns the
@@ -268,12 +268,15 @@ def generate_inputs(
         participant_label, exclude_participant_label
     )
 
-    # Attempt to validate with node bids-validator, if needed
-    validated = _validate_input_dir if not skip_bids_validation else None
+    # Attempt to validate with node bids-validator
+    validated = (
+        _validate_bids_dir
+        if not skip_bids_validation and not _all_custom_paths(pybids_inputs)
+        else None
+    )
 
-    # Generates a BIDSLayout
     # If not skipping validation, set validate indicator to opposite of output
-    # from _validate_input_dir, otherwise do not validate
+    # from _validate_bids_dir, otherwise do not validate
     layout = (
         _gen_bids_layout(
             bids_dir=bids_dir,
@@ -390,7 +393,7 @@ def _gen_bids_layout(
     )
 
 
-def _validate_input_dir(
+def _validate_bids_dir(
     bids_dir: Union[Path, str],
 ) -> bool:
     """Perform validation of dataset. Initial attempt at validation performed

--- a/snakebids/core/input_generation.py
+++ b/snakebids/core/input_generation.py
@@ -269,9 +269,8 @@ def generate_inputs(
     )
 
     # Attempt to validate with node bids-validator, if needed
-    if not skip_bids_validation:
-        validated = _validate_input_dir(bids_dir) 
-
+    validated = _validate_input_dir if not skip_bids_validation else None
+    
     # Generates a BIDSLayout
     # If not skipping validation, set validate indicator to opposite of output
     # from _validate_input_dir, otherwise do not validate

--- a/snakebids/core/input_generation.py
+++ b/snakebids/core/input_generation.py
@@ -270,7 +270,7 @@ def generate_inputs(
 
     # Attempt to validate with node bids-validator, if needed
     validated = _validate_input_dir if not skip_bids_validation else None
-    
+
     # Generates a BIDSLayout
     # If not skipping validation, set validate indicator to opposite of output
     # from _validate_input_dir, otherwise do not validate
@@ -351,7 +351,7 @@ def _gen_bids_layout(
         derivatives subdirectory of the input dataset.
 
     validate : bool
-        A boolean that indicates whether validation should be performed on 
+        A boolean that indicates whether validation should be performed on
         input dataset
 
     pybids_database_dir : str
@@ -394,9 +394,9 @@ def _validate_input_dir(
     bids_dir: Union[Path, str],
 ) -> bool:
     """Perform validation of dataset. Initial attempt at validation performed
-    with node-version of bids-validator. If not found, will fall back to 
+    with node-version of bids-validator. If not found, will fall back to
     validation integrated into pybids.
-    
+
     Parameters
     ----------
     bids_dir : str
@@ -408,16 +408,14 @@ def _validate_input_dir(
         Indication of whether validation was successfully performed using
         the node-version of bids-validator
     """
-    try: 
-        validator_config_dict = {
-            "ignoredFiles": ['/participants.tsv']
-        }
+    try:
+        validator_config_dict = {"ignoredFiles": ["/participants.tsv"]}
 
         with tempfile.NamedTemporaryFile(mode="w+", suffix=".json") as temp:
             temp.write(json.dumps(validator_config_dict))
             temp.flush()
 
-        subprocess.check_call(['bids-validator', str(bids_dir), '-c', temp.name])
+        subprocess.check_call(["bids-validator", str(bids_dir), "-c", temp.name])
 
         return True
     except FileNotFoundError:

--- a/snakebids/plugins/__init__.py
+++ b/snakebids/plugins/__init__.py
@@ -1,0 +1,6 @@
+__submodules__ = []
+
+# <AUTOGEN_INIT>
+__all__ = []
+
+# </AUTOGEN_INIT>

--- a/snakebids/plugins/validation.py
+++ b/snakebids/plugins/validation.py
@@ -1,0 +1,48 @@
+import json
+import logging
+import subprocess
+import tempfile
+
+from snakebids.app import SnakeBidsApp
+
+_logger = logging.getLogger(__name__)
+
+
+class InvalidBidsError(Exception):
+    """Error raised if an input BIDS dataset is invalid."""
+
+
+def bids_validate(app: SnakeBidsApp, bids_dir: str) -> None:
+    """Perform validation of dataset. Initial attempt at validation performed
+    with node-version of bids-validator. If not found, will fall back to Python
+    version of validation (same as pybids).
+
+    Parameters
+    ----------
+    app
+        Snakebids application to be run
+    bids_dir
+        BIDS organized directory to be validated
+    """
+
+    # Skip bids validation
+    if app.config["skip_bids_validation"]:
+        return
+
+    try:
+        validator_config_dict = {"ignoredFiles": ["/participants.tsv"]}
+
+        with tempfile.NamedTemporaryFile(mode="w+", suffix=".json") as temp:
+            temp.write(json.dumps(validator_config_dict))
+            temp.flush()
+
+        subprocess.check_call(["bids-validator", str(bids_dir), "-c", temp.name])
+    # If the bids-validator call can't be made
+    except FileNotFoundError:
+        _logger.warning(
+            "Bids-validator does not appear to be installed - will use python "
+            "validation."
+        )
+    # Any other bids-validator error
+    except subprocess.CalledProcessError as err:
+        raise InvalidBidsError from err

--- a/snakebids/project_template/{{cookiecutter.app_name}}/config/snakebids.yml
+++ b/snakebids/project_template/{{cookiecutter.app_name}}/config/snakebids.yml
@@ -40,6 +40,9 @@ pybids_inputs:
 # pybids_db_dir: '/path/to/db_dir' # Leave blank if you do not wish to use this
 # pybids_db_reset: False # Change this to true to update the database
 
+# Skipping of bids validation
+skip_bids_validation: False
+
 #configuration for the command-line parameters to make available
 # passed on the argparse add_argument()
 parse_args:

--- a/snakebids/project_template/{{cookiecutter.app_name}}/workflow/Snakefile
+++ b/snakebids/project_template/{{cookiecutter.app_name}}/workflow/Snakefile
@@ -14,6 +14,7 @@ inputs = snakebids.generate_inputs(
     derivatives=config.get("derivatives", None),
     participant_label=config.get("participant_label", None),
     exclude_participant_label=config.get("exclude_participant_label", None),
+    skip_bids_validation=config.get("skip_bids_validation", False),
     use_bids_inputs=True,
 )
 

--- a/snakebids/tests/data/dataset_description.json
+++ b/snakebids/tests/data/dataset_description.json
@@ -1,0 +1,4 @@
+{
+    "Name": "Snakebids - test dataset",
+    "BIDSVersion": "1.8.0"
+}

--- a/snakebids/tests/mock/config.yaml
+++ b/snakebids/tests/mock/config.yaml
@@ -22,6 +22,8 @@ pybids_inputs:
 pybids_db_dir: '/path/to/db_dir'
 pybids_db_reset: False
 
+skip_bids_validation: False
+
 targets_by_analysis_level:
   participant:
     - ''  # if '', then the first rule is run

--- a/snakebids/tests/test_app.py
+++ b/snakebids/tests/test_app.py
@@ -100,6 +100,7 @@ class TestRunSnakemake:
                 "pybids_db_reset": True,
                 "snakefile": Path("Snakefile"),
                 "output_dir": outputdir.resolve(),
+                "skip_bids_validation": False
             }
         )
         if root == "app" and tail == "":

--- a/snakebids/tests/test_app.py
+++ b/snakebids/tests/test_app.py
@@ -100,7 +100,7 @@ class TestRunSnakemake:
                 "pybids_db_reset": True,
                 "snakefile": Path("Snakefile"),
                 "output_dir": outputdir.resolve(),
-                "skip_bids_validation": False
+                "skip_bids_validation": False,
             }
         )
         if root == "app" and tail == "":

--- a/snakebids/tests/test_app.py
+++ b/snakebids/tests/test_app.py
@@ -100,7 +100,6 @@ class TestRunSnakemake:
                 "pybids_db_reset": True,
                 "snakefile": Path("Snakefile"),
                 "output_dir": outputdir.resolve(),
-                "skip_bids_validation": False,
             }
         )
         if root == "app" and tail == "":

--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -29,7 +29,7 @@ from snakebids.core.input_generation import (
     _generate_filters,
     _get_lists_from_bids,
     _parse_custom_path,
-    _validate_input_dir,
+    _validate_bids_dir,
     generate_inputs,
 )
 from snakebids.exceptions import ConfigError, PybidsError
@@ -1004,7 +1004,7 @@ class TestValidate:
 
     def test_check_validator(self):
         """Test validator defaults to pybids (i.e. False)"""
-        assert _validate_input_dir(self.bids_dir) == False
+        assert _validate_bids_dir(self.bids_dir) == False
 
     def test_pybids_validation_fail(self):
         with pytest.raises(BIDSValidationError):

--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -15,6 +15,7 @@ import attrs
 import more_itertools as itx
 import pytest
 from bids import BIDSLayout
+from bids.exceptions import BIDSValidationError
 from hypothesis import HealthCheck, assume, example, given, settings
 from hypothesis import strategies as st
 from pyfakefs.fake_filesystem import FakeFilesystem
@@ -996,6 +997,33 @@ def test_when_all_custom_paths_no_layout_indexed(
     assert reindexed == dataset
     assert reindexed.layout is None
     spy.assert_not_called()
+
+
+class TestValidate:
+    @pytest.fixture(autouse=True)
+    def start(self, tmpdir):
+        self.bids_dir = "snakebids/tests/data/bids_t1w"
+        self.tmp_dir = tmpdir.strpath
+
+        # Copy test data
+        shutil.copytree(self.bids_dir, f"{self.tmp_dir}/data")
+
+
+    def test_check_validator(self):
+        """Test validator defaults to pybids"""
+        assert _validate_input_dir(self.bids_dir) == False 
+
+
+    # Test for validation failure
+    def test_pybids_validation_fail(self):
+        with pytest.raises(BIDSValidationError):
+            _gen_bids_layout(
+                bids_dir=f"{self.tmp_dir}/data",
+                derivatives=False,
+                pybids_database_dir=None,
+                pybids_reset_database=False,
+                validate=True,
+            )
 
 
 class TestDB:

--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -98,10 +98,7 @@ class TestFilterBools:
 
         with pytest.raises(ConfigError):
             generate_inputs(
-                root, 
-                pybids_inputs, 
-                skip_bids_validation=True, 
-                use_bids_inputs=True
+                root, pybids_inputs, skip_bids_validation=True, use_bids_inputs=True
             )
 
     @settings(
@@ -129,10 +126,7 @@ class TestFilterBools:
 
         with pytest.raises(ConfigError):
             generate_inputs(
-                root, 
-                pybids_inputs, 
-                skip_bids_validation=True, 
-                use_bids_inputs=True
+                root, pybids_inputs, skip_bids_validation=True, use_bids_inputs=True
             )
 
     @settings(
@@ -169,10 +163,7 @@ class TestFilterBools:
         )
 
         data = generate_inputs(
-            root, 
-            pybids_inputs, 
-            skip_bids_validation=True, 
-            use_bids_inputs=True
+            root, pybids_inputs, skip_bids_validation=True, use_bids_inputs=True
         )
         assert data == expected
 
@@ -252,10 +243,7 @@ class TestFilterBools:
         )
 
         data = generate_inputs(
-            root, 
-            pybids_inputs, 
-            skip_bids_validation=True, 
-            use_bids_inputs=True
+            root, pybids_inputs, skip_bids_validation=True, use_bids_inputs=True
         )
         assert data == expected
 
@@ -1007,23 +995,35 @@ class TestValidate:
 
         # Copy test data
         shutil.copytree(self.bids_dir, f"{self.tmp_dir}/data")
+        assert filecmp.dircmp("snakebids/tests/data/bids_t1w", f"{self.tmp_dir}/data")
 
+        # Copy dataset description
+        shutil.copy(
+            "snakebids/tests/data/dataset_description.json", f"{self.tmp_dir}/data"
+        )
 
     def test_check_validator(self):
-        """Test validator defaults to pybids"""
-        assert _validate_input_dir(self.bids_dir) == False 
+        """Test validator defaults to pybids (i.e. False)"""
+        assert _validate_input_dir(self.bids_dir) == False
 
-
-    # Test for validation failure
     def test_pybids_validation_fail(self):
         with pytest.raises(BIDSValidationError):
             _gen_bids_layout(
-                bids_dir=f"{self.tmp_dir}/data",
+                bids_dir=self.bids_dir,
                 derivatives=False,
                 pybids_database_dir=None,
                 pybids_reset_database=False,
                 validate=True,
             )
+
+    def test_pybids_validation_pass(self):
+        assert _gen_bids_layout(
+            bids_dir=f"{self.tmp_dir}/data",
+            derivatives=False,
+            pybids_database_dir=None,
+            pybids_reset_database=False,
+            validate=True,
+        )
 
 
 class TestDB:


### PR DESCRIPTION
## Proposed changes

An attempt at implementing bids validation (see #222). As suggested, this first attempts to perform a system call to the bids-validator prior to running `_gen_bids_layout`. If this first attempt fails, it will fall back running the validation via pybids. Validation, in both cases, are skipped if all custom paths are given. I wasn't quite sure about how to go and add a test for the system call and haven't had a chance to test this locally. There are tests for pybids.

Drawing some inspiration from fmriprep, a temporary config file is generated for the system call in (`_validate_bids_dir`) which includes files to ignore during this validation. Was also wondering if we want to limit the validation to the subject data themselves rather than a full dataset (e.g. ignore `participants.tsv, dataset_description.json`)?

_Note to self_:
- [ ] `pybids` validation
- [ ] Add to snakebids app
- [ ] Tests

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [x] Changes pass the unit tests
- [x] I have included necessary documentation or comments (as necessary)
- [x] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.