### PR TITLE
Move target_rule to beginning of snakemake call

### DIFF
--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -233,6 +233,9 @@ class SnakeBidsApp:
                 *filter(
                     None,
                     [
+                        *app.config["targets_by_analysis_level"][
+                            app.config["analysis_level"]
+                        ],
                         "--snakefile",
                         str(app.snakefile_path),
                         "--directory",
@@ -240,9 +243,6 @@ class SnakeBidsApp:
                         "--configfile",
                         str(new_config_file.resolve()),
                         *app.config["snakemake_args"],
-                        *app.config["targets_by_analysis_level"][
-                            app.config["analysis_level"]
-                        ],
                     ],
                 )
             ]


### PR DESCRIPTION
The target was previously at the end of the call, but then if the last user-provided snakemake argument is something that consumes arguments (such as `-q`), the target gets misinterpreted and snakemake errors.
