### PR TITLE
Remove add_plugins method from SnakeBidsApp

### DIFF
--- a/docs/bids_app/plugins.md
+++ b/docs/bids_app/plugins.md
@@ -2,11 +2,11 @@
 
 Plugins are a Snakebids feature that allow you to add arbitrary behaviour to your Snakebids app after CLI arguments are parsed but before Snakemake is invoked. For example, you might add BIDS validation of an input dataset to your app via a plugin, so your app is only run if the input dataset is valid.
 
-A plugin is simply a function that takes a {class}`SnakeBidsApp <snakebids.app.SnakeBidsApp>` as input and returns either a modified {class}`SnakeBidsApp <snakebids.app.SnakeBidsApp>` or `None`. To add one or more plugins to your {class}`SnakeBidsApp <snakebids.app.SnakeBidsApp>`, use the method {func}`add_plugins <snakebids.app.SnakeBidsApp.add_plugins>`, which will typically be easiest in a `run.py` or similar entrypoint to your app. Your plugin will have access to CLI parameters (after they've been parsed) via their names in {attr}`SnakeBidsApp.config <snakebids.app.SnakeBidsApp.config>`. Any modifications to that config dictionary will be carried forward into the workflow.
+A plugin is simply a function that takes a {class}`SnakeBidsApp <snakebids.app.SnakeBidsApp>` as input and returns either a modified {class}`SnakeBidsApp <snakebids.app.SnakeBidsApp>` or `None`. To add one or more plugins to your {class}`SnakeBidsApp <snakebids.app.SnakeBidsApp>`, pass them to the {class}`~snakebids.app.SnakeBidsApp` constructor via the {attr}`~snakebids.app.SnakeBidsApp.plugins` parameter. Your plugin will have access to CLI parameters (after they've been parsed) via their names in {attr}`SnakeBidsApp.config <snakebids.app.SnakeBidsApp.config>`. Any modifications to that config dictionary will be carried forward into the workflow.
 
 As an example, a plugin could run the [BIDS Validator](https://github.com/bids-standard/bids-validator) on the input directory like so:
 
-```
+```py
 import subprocess
 
 from snakebids.app import SnakeBidsApp
@@ -23,10 +23,10 @@ def bids_validate(app: SnakeBidsApp) -> None:
 class InvalidBidsError(Exception):
     """Error raised if an input BIDS dataset is invalid."""
 
-app = SnakeBidsApp("path/to/snakebids/app")
-app.add_plugins([bids_validate])
-app.run_snakemake()
-
+SnakeBidsApp(
+    "path/to/snakebids/app",
+    plugins=[bids_validate]
+).run_snakemake()
 ```
 
 You would also want to add some logic to check if the BIDS Validator is installed and pass along the error message, but the point is that a plugin can do anything that can be handled by a Python function.

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
-from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -97,28 +96,8 @@ class SnakeBidsApp:
     args
         Arguments to use when running the app. By default, generated using the parser
         attribute, autopopulated with args from `config.py`
-    """
-
-    snakemake_dir: Path = attr.ib(converter=lambda path: Path(path).resolve())
-    skip_parse_args: bool = False
-    parser: argparse.ArgumentParser = create_parser()
-    configfile_path: Path = attr.Factory(
-        _get_file_paths(CONFIGFILE_CHOICES, "config"), takes_self=True
-    )
-    snakefile_path: Path = attr.Factory(
-        _get_file_paths(SNAKEFILE_CHOICES, "Snakefile"), takes_self=True
-    )
-    config: Dict[str, Any] = attr.Factory(
-        lambda self: load_configfile(self.snakemake_dir / self.configfile_path),
-        takes_self=True,
-    )
-    args: Optional[SnakebidsArgs] = None
-    plugins: list[Callable[[SnakeBidsApp], None | SnakeBidsApp]] = attr.Factory(list)
-
-    def add_plugins(
-        self, plugins: Iterable[Callable[[SnakeBidsApp], None | SnakeBidsApp]]
-    ) -> None:
-        """Supply list of methods to be called after CLI parsing.
+    plugins
+        List of methods to be called after CLI parsing.
 
         Each callable in ``plugins`` should take, as a single argument, a reference to
         the ``SnakeBidsApp``. Plugins may perform any arbitrary side effects, including
@@ -135,13 +114,23 @@ class SnakeBidsApp:
         - A ``SnakeBidsApp``, which will replace the existing instance, so this option
           should be used with care.
 
-        Parameters
-        ----------
-        plugins
-            List of plugins to be added
-        """
-        # pylint: disable=no-member
-        self.plugins.extend(plugins)
+    """
+
+    snakemake_dir: Path = attr.ib(converter=lambda path: Path(path).resolve())
+    plugins: list[Callable[[SnakeBidsApp], None | SnakeBidsApp]] = attr.Factory(list)
+    skip_parse_args: bool = False
+    parser: argparse.ArgumentParser = create_parser()
+    configfile_path: Path = attr.Factory(
+        _get_file_paths(CONFIGFILE_CHOICES, "config"), takes_self=True
+    )
+    snakefile_path: Path = attr.Factory(
+        _get_file_paths(SNAKEFILE_CHOICES, "Snakefile"), takes_self=True
+    )
+    config: Dict[str, Any] = attr.Factory(
+        lambda self: load_configfile(self.snakemake_dir / self.configfile_path),
+        takes_self=True,
+    )
+    args: Optional[SnakebidsArgs] = None
 
     def run_snakemake(self) -> None:
         """Run snakemake with the given config, after applying plugins"""

--- a/snakebids/tests/test_app.py
+++ b/snakebids/tests/test_app.py
@@ -22,7 +22,7 @@ from .mock.config import config
 def app(mocker: MockerFixture):
     app = SnakeBidsApp(
         Path("app"),
-        False,
+        skip_parse_args=False,
         snakefile_path=Path("Snakefile"),
         configfile_path=Path("mock/config.yaml"),
         config=copy.deepcopy(config),
@@ -77,7 +77,7 @@ class TestRunSnakemake:
         # Prepare app and initial config values
         app = SnakeBidsApp(
             Path("app"),
-            False,
+            skip_parse_args=False,
             snakefile_path=Path("Snakefile"),
             configfile_path=Path("mock/config.yaml"),
             config=copy.deepcopy(config),
@@ -181,7 +181,7 @@ class TestRunSnakemake:
         def plugin(my_app):
             my_app.foo = "bar"
 
-        app.add_plugins([plugin])
+        app.plugins.extend([plugin])
         try:
             app.run_snakemake()
         except SystemExit as e:


### PR DESCRIPTION
Wanted to sneak this in before the release so we don't need to do a breaking change later. 

Plugins can be trivially added via the constructor, or via SnakeBidsApp.plugins.append, so the method is redundant. Documentation and tests updated to reflect change