### PR TITLE
Update glob_wildcards to return ZipLists

### DIFF
--- a/snakebids/core/input_generation.py
+++ b/snakebids/core/input_generation.py
@@ -484,25 +484,17 @@ def _parse_custom_path(
     input_zip_list, input_list, input_wildcards
     """
     wildcards = glob_wildcards(input_path)
-    wildcard_names = list(wildcards._fields)
 
-    if len(wildcard_names) == 0:
+    if not wildcards:
         _logger.warning("No wildcards defined in %s", input_path)
 
-    # Initialize output values
-    zip_lists: Dict[str, List[str]] = {}
-
     # Log an error if no matches found
-    if len(wildcards[0]) == 0:
+    if len(next(iter(wildcards.values()))) == 0:
         _logger.error("No matching files for %s", input_path)
-        return zip_lists
-
-    # Loop through every wildcard name
-    for i, wildcard in enumerate(wildcard_names):
-        zip_lists[wildcard] = wildcards[i]
+        return wildcards
 
     # Return the output values, running filtering on the zip_lists
-    return filter_list(zip_lists, filters, regex_search=regex_search)
+    return filter_list(wildcards, filters, regex_search=regex_search)
 
 
 def _parse_bids_path(path: str, entities: Iterable[str]) -> Tuple[str, Dict[str, str]]:

--- a/snakebids/tests/test_snakemake_io.py
+++ b/snakebids/tests/test_snakemake_io.py
@@ -1,9 +1,4 @@
 """Tests for snakemake_io"""
-
-from __future__ import absolute_import
-
-import collections
-
 from snakebids.utils import snakemake_io
 
 
@@ -12,13 +7,13 @@ def test_glob_wildcards():
     file_path = (
         "snakebids/tests/data/bids_t1w/sub-001/anat/" "sub-001_acq-mprage_T1w.nii.gz"
     )
-    empty_wildcards = collections.namedtuple("Wildcards", [])()
+    empty_wildcards = {}
     assert snakemake_io.glob_wildcards(file_path) == empty_wildcards
 
     acq_wildcard_path = (
         "snakebids/tests/data/bids_t1w/sub-001/anat/" "sub-001_acq-{acq}_T1w.nii.gz"
     )
-    acq_wildcards = collections.namedtuple("Wildcards", ["acq"])(["mprage"])
+    acq_wildcards = {"acq": ["mprage"]}
     assert snakemake_io.glob_wildcards(acq_wildcard_path) == acq_wildcards
 
     # Order of wildcards in the namedtuple is not deterministic
@@ -27,22 +22,14 @@ def test_glob_wildcards():
         "sub-{subject}_acq-{acq}_T1w.nii.gz"
     )
     both_wildcards = [
-        collections.namedtuple("Wildcards", ["subject", "acq"])(
-            ["001", "002"], ["mprage", "mprage"]
-        ),
-        collections.namedtuple("Wildcards", ["subject", "acq"])(
-            ["002", "001"], ["mprage", "mprage"]
-        ),
-        collections.namedtuple("Wildcards", ["acq", "subject"])(
-            ["mprage", "mprage"], ["001", "002"]
-        ),
-        collections.namedtuple("Wildcards", ["acq", "subject"])(
-            ["mprage", "mprage"], ["002", "001"]
-        ),
+        {"subject": ["001", "002"], "acq": ["mprage", "mprage"]},
+        {"subject": ["002", "001"], "acq": ["mprage", "mprage"]},
+        {"acq": ["mprage", "mprage"], "subject": ["001", "002"]},
+        {"acq": ["mprage", "mprage"], "subject": ["002", "001"]},
     ]
     both_wildcards_one_file = [
-        collections.namedtuple("Wildcards", ["subject", "acq"])(["001"], ["mprage"]),
-        collections.namedtuple("Wildcards", ["acq", "subject"])(["mprage"], ["001"]),
+        {"subject": ["001"], "acq": ["mprage"]},
+        {"acq": ["mprage"], "subject": ["001"]},
     ]
 
     assert snakemake_io.glob_wildcards(both_wildcard_path) in both_wildcards


### PR DESCRIPTION
This issue's been sitting in the code latent for a while. Fixing it now because I want to use `glob_wildcards()` in some tests I'm writing.

The test suite could be expanded: using the zip_list strategies we already have is extremely low hanging fruit and would greatly simplify the existing test. And we don't actually test globbing over an actual filesystem. But I wanted to spin this off as fast as possible.