### PR TITLE
Switch default of use_bids_inputs to True

### DIFF
--- a/docs/bids_app/workflow.md
+++ b/docs/bids_app/workflow.md
@@ -20,7 +20,6 @@ inputs = snakebids.generate_inputs(
     derivatives=config.get("derivatives"),
     participant_label=config.get("participant_label"),
     exclude_participant_label=config.get("exclude_participant_label"),
-    use_bids_inputs=True,
 )
 
 ```

--- a/docs/tutorial/step6/Snakefile
+++ b/docs/tutorial/step6/Snakefile
@@ -5,7 +5,6 @@ configfile: 'config.yml'
 inputs = generate_inputs(
     bids_dir=config['bids_dir'],
     pybids_inputs=config['pybids_inputs'],
-    use_bids_inputs=True,
 )
 
 print(inputs)

--- a/docs/tutorial/step7/Snakefile
+++ b/docs/tutorial/step7/Snakefile
@@ -5,7 +5,6 @@ configfile: 'config.yml'
 inputs = generate_inputs(
     bids_dir=config['bids_dir'],
     pybids_inputs=config['pybids_inputs'],
-    use_bids_inputs=True,
 )
 
 rule all:

--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -314,7 +314,7 @@ To add this parsing to the workflow, we call the {func}`generate_inputs() <snake
 
 
 ```{note}
-Snakebids is transitioning to a new format for {func}`generate_inputs() <snakebids.generate_inputs()>`. Currently, you need to opt-in to the new features by setting `use_bids_inputs=True` in `generate_inputs()`, but it will become the default in an upcoming version. We recommend all new users opt-in to maintain long term support, so the tutorial is written using the new syntax. A tutorial for the old syntax can be found on [the v0.5.0 docs](https://snakebids.readthedocs.io/en/v0.5.0/tutorial/tutorial.html#part-ii-snakebids).
+Snakebids has transitioned to a new format for {func}`generate_inputs() <snakebids.generate_inputs()>`. To get access to the old dict style return, the `use_bids_inputs` parameter must be set to False. A tutorial for the old syntax can be found on [the v0.5.0 docs](https://snakebids.readthedocs.io/en/v0.5.0/tutorial/tutorial.html#part-ii-snakebids).
 ```
 
 

--- a/snakebids/core/datasets.py
+++ b/snakebids/core/datasets.py
@@ -214,6 +214,29 @@ class BidsDataset(UserDictPy37[str, BidsComponent]):
         super().__init__(data)
         self.layout = layout
 
+    def __getitem__(self, key: str):
+        try:
+            return super().__getitem__(key)
+        except KeyError as err:
+            if key in {
+                "input_path",
+                "input_zip_lists",
+                "input_lists",
+                "input_wildcards",
+                "subjects",
+                "sessions",
+                "subj_wildcards",
+            }:
+                raise KeyError(
+                    "As of v0.8, generate_inputs() no longer returns a dict by "
+                    f"default, but an instance of BidsDataset. As such, '{key}' can no "
+                    "longer be accessed via brackets '[]' as before. The original dict "
+                    "can be returned by setting `use_bids_inputs` to False in the call "
+                    "to generate_inputs(). However, we encourage you to transition to "
+                    "the use of `BidsDataset` for long term support"
+                ) from err
+            raise err
+
     def __setitem__(self, _: Any, __: Any):
         raise NotImplementedError(
             f"Modification of {self.__class__.__name__} is not yet supported"

--- a/snakebids/core/datasets.py
+++ b/snakebids/core/datasets.py
@@ -197,9 +197,7 @@ class BidsDataset(UserDictPy37[str, BidsComponent]):
     provided name, wildcards, and filters.
 
     Individual components can be accessed using bracket-syntax: (e.g.
-    ``inputs["t1w"]``). Component access attributes along with the component name in
-    brackets can also be used. For example, ``BidsDataset.entities["t1w"]`` and
-    ``BidsDataset["t1w"].entities`` return the same thing.
+    ``inputs["t1w"]``).
 
     Provides access to summarizing information, for instance, the set of all subjects or
     sessions found in the dataset.

--- a/snakebids/core/input_generation.py
+++ b/snakebids/core/input_generation.py
@@ -45,7 +45,7 @@ def generate_inputs(
     limit_to: list[str] | None = ...,
     participant_label: list[str] | None = ...,
     exclude_participant_label: list[str] | None = ...,
-    use_bids_inputs: Union[Literal[False], None] = ...,
+    use_bids_inputs: Literal[False] = ...,
 ) -> BidsDatasetDict:
     ...
 
@@ -62,7 +62,7 @@ def generate_inputs(
     limit_to: list[str] | None = ...,
     participant_label: list[str] | None = ...,
     exclude_participant_label: list[str] | None = ...,
-    use_bids_inputs: Literal[True] = ...,
+    use_bids_inputs: Literal[True] | None = ...,
 ) -> BidsDataset:
     ...
 
@@ -142,10 +142,9 @@ def generate_inputs(
         be specified if participant_label is specified
 
     use_bids_inputs
-        If True, opts in to the new :class:`BidsDataset` output, otherwise returns the
-        classic dict. Currently, the classic dict will be returned by default, however,
-        this will change in a future release. If you do not wish to migrate to the new
-        BidsDataset, we recommend you explictely set this parameter to False
+        If False, returns the classic :class:`BidsDatasetDict` instead of
+        :class`BidsDataset`. Setting to True is deprecated as of v0.8, as this is now
+        the default behaviour
 
     Returns
     -------
@@ -291,20 +290,14 @@ def generate_inputs(
         **(filters),
     )
 
-    if use_bids_inputs is None:
+    if use_bids_inputs is True:
         _logger.warning(
-            "The dictionary returned by generate_inputs() will soon be deprecated in "
-            "favour of the new BidsDataset class. BidsDataset provides the same "
-            "functionality of the dict, but with attribute access and new convience "
-            "methods. In a future release, generate_inputs() will return this class "
-            "by default. You can opt into this behaviour now by setting the "
-            "`use_bids_inputs` argument in generate_inputs() to True. If you do not "
-            "wish to migrate your code to BidsDataset at this time, we recommend you "
-            "explicately set `use_bids_inputs` to False. This will preserve the "
-            "current behaviour of returning a Dict in future releases, and will "
-            "silence this warning."
+            "The parameter `use_bids_inputs` in generate_inputs() is now set, by "
+            "default, to True. Manually setting it to True is deprecated as of version "
+            "0.8. "
         )
-        use_bids_inputs = False
+    elif use_bids_inputs is None:
+        use_bids_inputs = True
 
     try:
         dataset = BidsDataset.from_iterable(bids_inputs, layout)

--- a/snakebids/project_template/{{cookiecutter.app_name}}/workflow/Snakefile
+++ b/snakebids/project_template/{{cookiecutter.app_name}}/workflow/Snakefile
@@ -14,7 +14,6 @@ inputs = snakebids.generate_inputs(
     derivatives=config.get("derivatives", None),
     participant_label=config.get("participant_label", None),
     exclude_participant_label=config.get("exclude_participant_label", None),
-    use_bids_inputs=True,
 )
 
 

--- a/snakebids/tests/helpers.py
+++ b/snakebids/tests/helpers.py
@@ -175,7 +175,7 @@ def reindex_dataset(root: str, dataset: BidsDataset, use_custom_paths: bool = Fa
     if use_custom_paths:
         for comp in config:
             config[comp]["custom_path"] = dataset[comp].path
-    return generate_inputs(root, config, use_bids_inputs=True)
+    return generate_inputs(root, config)
 
 
 def allow_tmpdir(__callable: T) -> T:

--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -95,7 +95,7 @@ class TestFilterBools:
         }
 
         with pytest.raises(ConfigError):
-            generate_inputs(root, pybids_inputs, use_bids_inputs=True)
+            generate_inputs(root, pybids_inputs)
 
     @settings(
         deadline=800,
@@ -121,7 +121,7 @@ class TestFilterBools:
         }
 
         with pytest.raises(ConfigError):
-            generate_inputs(root, pybids_inputs, use_bids_inputs=True)
+            generate_inputs(root, pybids_inputs)
 
     @settings(
         deadline=800,
@@ -156,7 +156,7 @@ class TestFilterBools:
             }
         )
 
-        data = generate_inputs(root, pybids_inputs, use_bids_inputs=True)
+        data = generate_inputs(root, pybids_inputs)
         assert data == expected
 
     @example(
@@ -234,7 +234,7 @@ class TestFilterBools:
             }
         )
 
-        data = generate_inputs(root, pybids_inputs, use_bids_inputs=True)
+        data = generate_inputs(root, pybids_inputs)
         assert data == expected
 
 
@@ -269,7 +269,6 @@ class TestAbsentConfigEntries:
             bids_dir=tmpdir,
             derivatives=derivatives,
             pybids_config=str(Path(__file__).parent / "data" / "custom_config.json"),
-            use_bids_inputs=True,
         )
         template = BidsDataset({"t1": BidsComponent("t1", config["t1"].path, zip_list)})
         # Order of the subjects is not deterministic
@@ -293,7 +292,6 @@ class TestAbsentConfigEntries:
             bids_dir=tmpdir,
             derivatives=derivatives,
             pybids_config=str(Path(__file__).parent / "data" / "custom_config.json"),
-            use_bids_inputs=True,
         )
         template = BidsDataset({"t1": BidsComponent("t1", config["t1"].path, {})})
         assert template == config
@@ -553,7 +551,6 @@ def test_custom_pybids_config(tmpdir: Path):
         bids_dir=tmpdir,
         derivatives=derivatives,
         pybids_config=Path(__file__).parent / "data" / "custom_config.json",
-        use_bids_inputs=True,
     )
     template = BidsDataset(
         {
@@ -605,7 +602,6 @@ def test_nonstandard_custom_pybids_config(tmpdir: Path):
             pybids_config=(
                 Path(__file__).parent / "data" / "custom_config_nonstandard.json"
             ),
-            use_bids_inputs=True,
         )
 
 
@@ -639,7 +635,6 @@ def test_t1w():
         pybids_inputs=pybids_inputs,
         bids_dir=real_bids_dir,
         derivatives=derivatives,
-        use_bids_inputs=True,
     )
     template = BidsDataset(
         {
@@ -674,7 +669,6 @@ def test_t1w():
         bids_dir=real_bids_dir,
         derivatives=derivatives,
         participant_label="001",
-        use_bids_inputs=True,
     )
     assert result["scan"].entities == {
         "acq": ["mprage"],
@@ -745,7 +739,6 @@ def test_t1w():
             pybids_inputs=pybids_inputs,
             bids_dir=bids_dir,
             derivatives=derivatives,
-            use_bids_inputs=True,
         )
         template = BidsDataset(
             {

--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -776,6 +776,7 @@ def test_t1w_with_dict():
         pybids_inputs=pybids_inputs,
         bids_dir=real_bids_dir,
         derivatives=derivatives,
+        use_bids_inputs=False,
     )
     # Order of the subjects is not deterministic
     assert config["input_lists"] == BidsListCompare(
@@ -807,6 +808,7 @@ def test_t1w_with_dict():
         bids_dir=real_bids_dir,
         derivatives=derivatives,
         participant_label="001",
+        use_bids_inputs=False,
     )
     assert config["input_lists"] == {
         "scan": {"acq": ["mprage"], "subject": ["001"], "suffix": ["T1w"]}


### PR DESCRIPTION
I thought it was about time we made this switch.

In addition to switching the default, I'd like to deprecate manually setting `use_bids_inputs=True` to attempt to cleanse code of this line. Perhaps we can even remove it completely one day.

One thing I did that I'm not sure any more is helpful is attempt to detect people using `BidsDataset` as if it were `BidsDatasetDict`. If a key from `BidsDatasetDict` is given to `BidsDataset`, and that key is not present in the dataset as a component, an informative error message will be printed. The problem is that the legacy code that might benefit from such a warning are also probably still using the old `config.update(generate_inputs(...))` style. In this case, all the properties from `BidsDataset` will be copied from out of the dataset into the config object, and we lose the opportunity to give the warning. So I'm not sure it's worth even including this warning, as I'd still need to write tests for it, and I doubt anyone will ever see it. Thoughts?