### PR TITLE
Remove unnecessary `use_bids_inputs = True`

### DIFF
--- a/snakebids/core/input_generation.py
+++ b/snakebids/core/input_generation.py
@@ -35,8 +35,8 @@ def generate_inputs(  # noqa: PLR0913
     limit_to: Iterable[str] | None = ...,
     participant_label: Iterable[str] | str | None = ...,
     exclude_participant_label: Iterable[str] | str | None = ...,
-    use_bids_inputs: Literal[False] = ...,
-) -> BidsDatasetDict:
+    use_bids_inputs: Literal[True] | None = ...,
+) -> BidsDataset:
     ...
 
 
@@ -51,8 +51,8 @@ def generate_inputs(  # noqa: PLR0913
     limit_to: Iterable[str] | None = ...,
     participant_label: Iterable[str] | str | None = ...,
     exclude_participant_label: Iterable[str] | str | None = ...,
-    use_bids_inputs: Literal[True] | None = ...,
-) -> BidsDataset:
+    use_bids_inputs: Literal[False] = ...,
+) -> BidsDatasetDict:
     ...
 
 

--- a/snakebids/tests/helpers.py
+++ b/snakebids/tests/helpers.py
@@ -204,7 +204,7 @@ def reindex_dataset(
     if use_custom_paths:
         for comp in config:
             config[comp]["custom_path"] = dataset[comp].path
-    return generate_inputs(root, config, use_bids_inputs=True)
+    return generate_inputs(root, config)
 
 
 def allow_tmpdir(__callable: _T) -> _T:

--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -284,7 +284,6 @@ class TestAbsentConfigEntries:
             bids_dir=tmpdir,
             derivatives=derivatives,
             pybids_config=str(Path(__file__).parent / "data" / "custom_config.json"),
-            use_bids_inputs=True,
         )
         template = BidsDataset({"t1": BidsComponent("t1", config["t1"].path, zip_list)})
         # Order of the subjects is not deterministic
@@ -308,7 +307,6 @@ class TestAbsentConfigEntries:
             pybids_inputs=pybids_inputs,
             derivatives=derivatives,
             pybids_config=str(Path(__file__).parent / "data" / "custom_config.json"),
-            use_bids_inputs=True,
         )
         template = BidsDataset(
             {"t1": BidsComponent("t1", config["t1"].path, MultiSelectDict({}))}
@@ -580,7 +578,6 @@ def test_custom_pybids_config(tmpdir: Path):
         bids_dir=tmpdir,
         derivatives=derivatives,
         pybids_config=str(Path(__file__).parent / "data" / "custom_config.json"),
-        use_bids_inputs=True,
     )
     template = BidsDataset(
         {
@@ -665,7 +662,6 @@ def test_t1w():
         pybids_inputs=pybids_inputs,
         bids_dir=real_bids_dir,
         derivatives=derivatives,
-        use_bids_inputs=True,
     )
     template = BidsDataset(
         {
@@ -702,7 +698,6 @@ def test_t1w():
         bids_dir=real_bids_dir,
         derivatives=derivatives,
         participant_label="001",
-        use_bids_inputs=True,
     )
     assert result["scan"].entities == {
         "acq": ["mprage"],
@@ -775,7 +770,6 @@ def test_t1w():
             pybids_inputs=pybids_inputs,
             bids_dir=bids_dir,
             derivatives=derivatives,
-            use_bids_inputs=True,
         )
         template = BidsDataset(
             {


### PR DESCRIPTION
No behaviour change, just eliminate the warnings from the test suite

Also changed the order of `generate_inputs`. The default return value needs to be first for typing to work properly