### PR TITLE
Implement `BidsPartialComponent`

### DIFF
--- a/docs/api/main.rst
+++ b/docs/api/main.rst
@@ -8,8 +8,14 @@ API
 snakebids
 ---------
 
+.. autoclass:: snakebids.BidsComponent
+    :members:
+    :inherited-members:
+
+.. autoclass:: snakebids.BidsPartialComponent
+
 .. automodule:: snakebids
-    :exclude-members: from_bids_lists
+    :exclude-members: from_bids_lists, BidsComponent, BidsPartialComponent
     :members:
 
 app

--- a/docs/api/main.rst
+++ b/docs/api/main.rst
@@ -10,13 +10,55 @@ snakebids
 
 .. autoclass:: snakebids.BidsComponent
     :members:
+    :exclude-members: input_wildcards, input_lists, input_name, input_path, input_zip_lists
     :inherited-members:
+
+.. dropdown:: Legacy ``BidsComponents`` properties
+    :icon: info
+    :class-title: sd-outline-info
+
+    The following properties are historical aliases of ``BidsComponents`` properties. There are no current plans to deprecate them, but new code should avoid them.
+
+    .. autoproperty:: snakebids.BidsComponent.input_zip_lists
+
+    .. autoproperty:: snakebids.BidsComponent.input_wildcards
+
+    .. autoproperty:: snakebids.BidsComponent.input_name
+
+    .. autoproperty:: snakebids.BidsComponent.input_path
+
+    .. autoproperty:: snakebids.BidsComponent.input_lists
+
 
 .. autoclass:: snakebids.BidsPartialComponent
 
-.. automodule:: snakebids
-    :exclude-members: from_bids_lists, BidsComponent, BidsPartialComponent
+.. autoclass:: snakebids.BidsComponentRow
     :members:
+    :exclude-members: zip_lists
+
+.. autoclass:: snakebids.BidsDataset
+    :members:
+    :exclude-members: input_wildcards, input_lists, input_path, input_zip_lists
+
+.. dropdown:: Legacy ``BidsDataset`` properties
+    :icon: info
+    :class-title: sd-outline-info
+
+    The following properties are historical aliases of :class:`~snakebids.BidsDataset` properties. There are no current plans to deprecate them, but new code should avoid them.
+
+    .. autoproperty:: snakebids.BidsDataset.input_zip_lists
+
+    .. autoproperty:: snakebids.BidsDataset.input_wildcards
+
+    .. autoproperty:: snakebids.BidsDataset.input_path
+
+    .. autoproperty:: snakebids.BidsDataset.input_lists
+
+
+.. automodule:: snakebids
+    :exclude-members: from_bids_lists, BidsComponent, BidsPartialComponent, BidsComponentRow, BidsDataset
+    :members:
+
 
 app
 ---

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,7 @@ extensions = [
     "myst_parser",
     "sphinx_copybutton",
     "sphinx_reredirects",
+    "sphinx_design",
 ]
 
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ myst-parser>=1.0.0,<2.0
 furo>=2023.3.23,<2024
 sphinx_copybutton>=0.5.1,<0.6
 sphinx-reredirects>=0.1,<0.2
+sphinx_design>=0.4.1,<0.5.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -726,14 +726,14 @@ pyreadline3 = {version = "*", markers = "sys_platform == \"win32\" and python_ve
 
 [[package]]
 name = "hypothesis"
-version = "6.79.1"
+version = "6.79.2"
 description = "A library for property-based testing"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "hypothesis-6.79.1-py3-none-any.whl", hash = "sha256:7a0b8ca178f16720e96f11e96b71b6139db0e30727e9cf8bd8e3059710393fc7"},
-    {file = "hypothesis-6.79.1.tar.gz", hash = "sha256:de8fb599fc855d3006236ab58cd0edafd099d63837225aad848dac22e239475b"},
+    {file = "hypothesis-6.79.2-py3-none-any.whl", hash = "sha256:564d9860ed5e09b0434b7bafea392b0da8f67131190202c6002e58c2c96b7596"},
+    {file = "hypothesis-6.79.2.tar.gz", hash = "sha256:51fb2259489dc446d3edc04cbc8ebd5848d7d3f238121183bee5449b91f7a8d8"},
 ]
 
 [package.dependencies]
@@ -2635,14 +2635,14 @@ files = [
 
 [[package]]
 name = "snakemake"
-version = "7.28.3"
+version = "7.29.0"
 description = "Workflow management system to create reproducible and scalable data analyses"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "snakemake-7.28.3-py3-none-any.whl", hash = "sha256:b16e2ab7145cc0f791a49f27fe5335dfeed295bbc43400501b8bb92328fecd2e"},
-    {file = "snakemake-7.28.3.tar.gz", hash = "sha256:4d0d5f9643d97154cd8925830bdb3922e4bd9cfcf7f8b619df75e4ddfdbc3f9e"},
+    {file = "snakemake-7.29.0-py3-none-any.whl", hash = "sha256:882b429738f0ca818665c995bf58e158da49ba4ad9ccc297f204bb10a8fb91d1"},
+    {file = "snakemake-7.29.0.tar.gz", hash = "sha256:c420a545924b599390efe9e2fa7a07c01d167cceac63d1d06fa6eff5e7b43be0"},
 ]
 
 [package.dependencies]
@@ -2656,6 +2656,7 @@ humanfriendly = "*"
 jinja2 = ">=3.0,<4.0"
 jsonschema = "*"
 nbformat = "*"
+packaging = "*"
 psutil = "*"
 pulp = ">=2.0"
 pyyaml = "*"

--- a/snakebids/__init__.py
+++ b/snakebids/__init__.py
@@ -1,4 +1,3 @@
-"""Top-level namespace containing the core classes and functions"""
 __submodules__ = ["core"]
 
 __version__ = "0.0.0"
@@ -8,6 +7,7 @@ from snakebids.core import (
     BidsComponent,
     BidsDataset,
     BidsDatasetDict,
+    BidsPartialComponent,
     bids,
     filter_list,
     generate_inputs,
@@ -21,6 +21,7 @@ __all__ = [
     "BidsComponent",
     "BidsDataset",
     "BidsDatasetDict",
+    "BidsPartialComponent",
     "bids",
     "filter_list",
     "generate_inputs",

--- a/snakebids/__init__.py
+++ b/snakebids/__init__.py
@@ -5,6 +5,7 @@ __version__ = "0.0.0"
 # <AUTOGEN_INIT>
 from snakebids.core import (
     BidsComponent,
+    BidsComponentRow,
     BidsDataset,
     BidsDatasetDict,
     BidsPartialComponent,
@@ -19,6 +20,7 @@ from snakebids.core import (
 
 __all__ = [
     "BidsComponent",
+    "BidsComponentRow",
     "BidsDataset",
     "BidsDatasetDict",
     "BidsPartialComponent",

--- a/snakebids/core/__init__.py
+++ b/snakebids/core/__init__.py
@@ -4,7 +4,12 @@ __ignore__ = ["T_co"]
 
 # <AUTOGEN_INIT>
 from snakebids.core.construct_bids import bids, print_boilerplate
-from snakebids.core.datasets import BidsComponent, BidsDataset, BidsDatasetDict
+from snakebids.core.datasets import (
+    BidsComponent,
+    BidsDataset,
+    BidsDatasetDict,
+    BidsPartialComponent,
+)
 from snakebids.core.filtering import filter_list, get_filtered_ziplist_index
 from snakebids.core.input_generation import (
     generate_inputs,
@@ -16,6 +21,7 @@ __all__ = [
     "BidsComponent",
     "BidsDataset",
     "BidsDatasetDict",
+    "BidsPartialComponent",
     "bids",
     "filter_list",
     "generate_inputs",

--- a/snakebids/core/__init__.py
+++ b/snakebids/core/__init__.py
@@ -6,6 +6,7 @@ __ignore__ = ["T_co"]
 from snakebids.core.construct_bids import bids, print_boilerplate
 from snakebids.core.datasets import (
     BidsComponent,
+    BidsComponentRow,
     BidsDataset,
     BidsDatasetDict,
     BidsPartialComponent,
@@ -19,6 +20,7 @@ from snakebids.core.input_generation import (
 
 __all__ = [
     "BidsComponent",
+    "BidsComponentRow",
     "BidsDataset",
     "BidsDatasetDict",
     "BidsPartialComponent",

--- a/snakebids/core/datasets.py
+++ b/snakebids/core/datasets.py
@@ -184,9 +184,7 @@ class BidsPartialComponent:
         if isinstance(__key, tuple):
             # Use dict.fromkeys for de-duplication
             return BidsPartialComponent(
-                zip_lists=MultiSelectDict(
-                    {key: self.zip_lists[key] for key in dict.fromkeys(__key)}
-                )
+                zip_lists={key: self.zip_lists[key] for key in dict.fromkeys(__key)}
             )
         return BidsComponentRow(self.zip_lists[__key], entity=__key)
 

--- a/snakebids/core/datasets.py
+++ b/snakebids/core/datasets.py
@@ -133,7 +133,11 @@ class BidsComponentRow(ImmutableList[str]):
         )
 
     def filter(
-        self, *, regex_search: bool = False, **filters: str | Iterable[str]
+        self,
+        __spec: str | Iterable[str] | None = None,
+        *,
+        regex_search: bool = False,
+        **filters: str | Iterable[str],
     ) -> Self:
         """Filter component based on provided entity filters
 
@@ -149,14 +153,24 @@ class BidsComponentRow(ImmutableList[str]):
 
         Parameters
         ----------
+        __spec
+            Value or iterable of values assocatiated with the ComponentRow's
+            :attr:`~snakebids.BidsComponentRow.entity`. Equivalent to specifying
+            ``.filter(entity=value)``
         regex_search
             Treat filters as regex patterns when matching with entity-values.
         filters
-            Each keyword should be the name of an entity in the component. Entities not
-            found in the component will be ignored. Keywords take values or a list of
-            values to be matched with the component
-            :attr:`~snakebids.BidsComponent.zip_lists`
+            Keyword-value(s) filters as in :meth:`~snakebids.BidsComponent.filter`.
+            Here, the only valid filter is the
+            :attr:`~snakebids.BidsComponentRow.entity` of the
+            :class:`~snakebids.BidsComponentRow`; all others will be ignored.
         """
+        if __spec is not None:
+            if filters:
+                raise ValueError(
+                    "Both __spec and filters cannot be used simultaneously"
+                )
+            filters = {self.entity: __spec}
         entity, data = itx.first(
             filter_list(
                 {self.entity: self._data}, filters, regex_search=regex_search

--- a/snakebids/core/datasets.py
+++ b/snakebids/core/datasets.py
@@ -96,7 +96,7 @@ class BidsComponentRow(ImmutableList[str]):
 
     def expand(
         self,
-        paths: Iterable[Path | str] | Path | str,
+        __paths: Iterable[Path | str] | Path | str,
         allow_missing: bool = False,
         **wildcards: str | Iterable[str],
     ) -> list[str]:
@@ -114,7 +114,7 @@ class BidsComponentRow(ImmutableList[str]):
 
         Parameters
         ==========
-        paths:
+        __paths:
             Path or list of paths to expand over
         allow_missing:
             If True, allow ``{wildcards}`` in the provided paths that are not present
@@ -126,7 +126,7 @@ class BidsComponentRow(ImmutableList[str]):
             lists of values to be expanded over the provided paths.
         """
         return sn_expand(
-            list(itx.always_iterable(paths)),
+            list(itx.always_iterable(__paths)),
             allow_missing=allow_missing,
             **{self.entity: list(set(self._data))},
             **{
@@ -340,7 +340,7 @@ class BidsPartialComponent:
 
     def expand(
         self,
-        paths: Iterable[Path | str] | Path | str,
+        __paths: Iterable[Path | str] | Path | str,
         allow_missing: bool = False,
         **wildcards: str | Iterable[str],
     ) -> list[str]:
@@ -358,7 +358,7 @@ class BidsPartialComponent:
 
         Parameters
         ==========
-        paths:
+        __paths:
             Path or list of paths to expand over
         allow_missing:
             If True, allow ``{wildcards}`` in the provided paths that are not present
@@ -372,7 +372,7 @@ class BidsPartialComponent:
         inner_expand = list(
             set(
                 sn_expand(
-                    list(itx.always_iterable(paths)),
+                    list(itx.always_iterable(__paths)),
                     zip,
                     allow_missing=True if wildcards else allow_missing,
                     **self.zip_lists,
@@ -515,7 +515,7 @@ class BidsComponent(BidsPartialComponent):
 
     def expand(
         self,
-        paths: Iterable[Path | str] | Path | str | None = None,
+        __paths: Iterable[Path | str] | Path | str | None = None,
         allow_missing: bool = False,
         **wildcards: str | Iterable[str],
     ) -> list[str]:
@@ -535,7 +535,7 @@ class BidsComponent(BidsPartialComponent):
 
         Parameters
         ==========
-        paths:
+        __paths:
             Path or list of paths to expand over. If not provided, the component's own
             :attr:`~BidsComponent.path` will be expanded over.
         allow_missing:
@@ -547,7 +547,7 @@ class BidsComponent(BidsPartialComponent):
             Keywords not found in the path will be ignored. Keywords take values or
             lists of values to be expanded over the provided paths.
         """
-        paths = paths or self.path
+        paths = __paths or self.path
         return super().expand(paths, allow_missing, **wildcards)
 
     @property

--- a/snakebids/core/datasets.py
+++ b/snakebids/core/datasets.py
@@ -65,6 +65,9 @@ class BidsComponentRow(ImmutableList[str]):
         super().__init__(__iterable)
         self.entity = entity
 
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__}({list(self._data)}, entity="{self.entity}")'
+
     @property
     def entities(self) -> tuple[str]:
         """The unique values associated with the component"""
@@ -125,7 +128,7 @@ class BidsComponentRow(ImmutableList[str]):
         return sn_expand(
             list(itx.always_iterable(paths)),
             allow_missing=allow_missing,
-            **{self.entity: self._data},
+            **{self.entity: list(set(self._data))},
             **{
                 wildcard: list(itx.always_iterable(v))
                 for wildcard, v in wildcards.items()
@@ -366,11 +369,15 @@ class BidsPartialComponent:
             Keywords not found in the path will be ignored. Keywords take values or
             lists of values to be expanded over the provided paths.
         """
-        inner_expand = sn_expand(
-            list(itx.always_iterable(paths)),
-            zip,
-            allow_missing=True if wildcards else allow_missing,
-            **self.zip_lists,
+        inner_expand = list(
+            set(
+                sn_expand(
+                    list(itx.always_iterable(paths)),
+                    zip,
+                    allow_missing=True if wildcards else allow_missing,
+                    **self.zip_lists,
+                )
+            )
         )
         if not wildcards:
             return inner_expand

--- a/snakebids/core/datasets.py
+++ b/snakebids/core/datasets.py
@@ -133,7 +133,7 @@ class BidsComponentRow(ImmutableList[str]):
         )
 
     def filter(
-        self, *, regex_search: bool = False, **filters: str | Sequence[str]
+        self, *, regex_search: bool = False, **filters: str | Iterable[str]
     ) -> Self:
         """Filter component based on provided entity filters
 

--- a/snakebids/core/datasets.py
+++ b/snakebids/core/datasets.py
@@ -25,6 +25,7 @@ from snakebids.types import UserDictPy37, ZipList
 from snakebids.utils.utils import (
     ImmutableList,
     MultiSelectDict,
+    get_wildcard_dict,
     property_alias,
     zip_list_eq,
 )
@@ -226,9 +227,7 @@ class BidsPartialComponent:
         the Snakemake wildcard used for that entity.
         """
         if self._input_wildcards is None:
-            self._input_wildcards = MultiSelectDict(
-                {entity: f"{{{entity}}}" for entity in self.zip_lists}
-            )
+            self._input_wildcards = MultiSelectDict(get_wildcard_dict(self.zip_lists))
         return self._input_wildcards
 
     @property

--- a/snakebids/core/input_generation.py
+++ b/snakebids/core/input_generation.py
@@ -25,12 +25,7 @@ from snakebids.exceptions import (
 )
 from snakebids.types import InputsConfig, ZipList
 from snakebids.utils.snakemake_io import glob_wildcards
-from snakebids.utils.utils import (
-    BidsEntity,
-    BidsParseError,
-    MultiSelectDict,
-    get_first_dir,
-)
+from snakebids.utils.utils import BidsEntity, BidsParseError, get_first_dir
 
 _logger = logging.getLogger(__name__)
 
@@ -600,7 +595,7 @@ def _get_lists_from_bids(
                 **pybids_inputs[input_name].get("filters", {}),
                 **filters,
             )
-            yield BidsComponent(input_name, path, MultiSelectDict(zip_lists))
+            yield BidsComponent(name=input_name, path=path, zip_lists=zip_lists)
             continue
 
         if bids_layout is None:
@@ -689,7 +684,7 @@ def _get_lists_from_bids(
                 f"narrow the search. Found filenames: {paths}"
             )
 
-        yield BidsComponent(input_name, path, MultiSelectDict(zip_lists))
+        yield BidsComponent(name=input_name, path=path, zip_lists=zip_lists)
 
 
 def get_wildcard_constraints(image_types: InputsConfig) -> dict[str, str]:

--- a/snakebids/tests/conftest.py
+++ b/snakebids/tests/conftest.py
@@ -67,5 +67,4 @@ def bids_fs(fakefs: Optional[FakeFilesystem]) -> FakeFilesystem | None:
         fakefs.add_real_file(f / "bids.json")
         fakefs.add_real_file(f / "derivatives.json")
         fakefs.add_real_file(Path(*resources.__path__) / "bids_tags.json")
-
     return fakefs

--- a/snakebids/tests/strategies.py
+++ b/snakebids/tests/strategies.py
@@ -358,7 +358,6 @@ def bids_components(  # noqa: PLR0913
 def expandables(  # noqa: PLR0913
     draw: st.DrawFn,
     *,
-    min_entities: int = 1,
     max_entities: int = 5,
     min_values: int = 1,
     max_values: int = 3,
@@ -375,7 +374,7 @@ def expandables(  # noqa: PLR0913
     return draw(
         st.one_of(
             bids_partial_components(
-                min_entities=min_entities,
+                min_entities=1,
                 max_entities=max_entities,
                 min_values=min_values,
                 max_values=max_values,

--- a/snakebids/tests/strategies.py
+++ b/snakebids/tests/strategies.py
@@ -242,10 +242,17 @@ def bids_component_row(  # noqa: PLR0913
     whitelist_entities: Optional[Container[BidsEntity | str]] = None,
     restrict_patterns: bool = False,
     unique: bool = False,
+    path_safe: bool = False,
 ) -> BidsComponentRow:
     entity = entity or draw(
         bids_entity(
-            blacklist_entities=blacklist_entities, whitelist_entities=whitelist_entities
+            blacklist_entities=helpers.ContainerBag(
+                blacklist_entities if blacklist_entities is not None else {},
+                {"datatype", "suffix", "extension"},
+            )
+            if path_safe
+            else blacklist_entities,
+            whitelist_entities=whitelist_entities,
         )
     )
     values = draw(
@@ -387,6 +394,7 @@ def expandables(  # noqa: PLR0913
     restrict_patterns: bool = False,
     unique: bool = False,
     cull: bool = True,
+    path_safe: bool = False,
 ) -> Expandable:
     def get_entity(_entities: Optional[list[BidsEntity]]) -> BidsEntity | None:
         if not _entities:
@@ -415,6 +423,7 @@ def expandables(  # noqa: PLR0913
                 whitelist_entities=whitelist_entities,
                 restrict_patterns=restrict_patterns,
                 unique=unique,
+                path_safe=path_safe,
             ),
         )
     )

--- a/snakebids/tests/strategies.py
+++ b/snakebids/tests/strategies.py
@@ -6,7 +6,7 @@ import sys
 from os import PathLike
 from pathlib import Path
 from string import ascii_letters, digits
-from typing import Any, Container, Iterable, Optional, Type, TypeVar
+from typing import Any, Container, Hashable, Iterable, Optional, Type, TypeVar
 
 import hypothesis.strategies as st
 from bids.layout import Config as BidsConfig
@@ -359,3 +359,27 @@ def multiselect_dicts(
 
 def everything() -> st.SearchStrategy[Any]:
     return st.from_type(type).flatmap(st.from_type)
+
+
+def _is_hashable(__item: Any):
+    try:
+        hash(__item)
+        return True
+    except TypeError:
+        return False
+
+
+def _supports_eq(__item: Any):
+    try:
+        __item == 0  # type: ignore
+        return True
+    except Exception:
+        return False
+
+
+def hashables() -> st.SearchStrategy[Hashable]:
+    return everything().filter(_is_hashable)
+
+
+def partially_ordered() -> st.SearchStrategy[Any]:
+    return everything().filter(_supports_eq)

--- a/snakebids/tests/test_datasets.py
+++ b/snakebids/tests/test_datasets.py
@@ -355,7 +355,7 @@ class TestFiltering:
     def get_filter_dict(
         self,
         data: st.DataObject,
-        component: BidsComponent,
+        component: Expandable,
         allow_extra_filters: bool = False,
     ):
         filter_dict: dict[str, list[str] | str] = {}
@@ -374,11 +374,13 @@ class TestFiltering:
             )
         )
 
+        entities = {key: list(set(vals)) for key, vals in component.zip_lists.items()}
+
         def value_strat(filt: str):
             rand_text = st.text(sb_st.alphanum, min_size=1, max_size=10)
             return (
-                st.one_of([st.sampled_from(component.entities[filt]), rand_text])
-                if filt in component.entities
+                st.one_of([st.sampled_from(entities[filt]), rand_text])
+                if filt in entities
                 else rand_text
             )
 
@@ -403,7 +405,7 @@ class TestFiltering:
         data=st.data(),
     )
     def test_only_filter_values_in_output(
-        self, component: BidsComponent, data: st.DataObject
+        self, component: Expandable, data: st.DataObject
     ):
         filter_dict = self.get_filter_dict(data, component)
         filtered = component.filter(**filter_dict)
@@ -412,11 +414,11 @@ class TestFiltering:
                 assert val in filter_dict[filt]
 
     @given(
-        component=sb_st.bids_components(max_values=4, restrict_patterns=True),
+        component=sb_st.expandables(max_values=4, restrict_patterns=True),
         data=st.data(),
     )
     def test_zip_lists_rows_remain_of_equal_length(
-        self, component: BidsComponent, data: st.DataObject
+        self, component: Expandable, data: st.DataObject
     ):
         filter_dict = self.get_filter_dict(data, component)
         filtered = component.filter(**filter_dict)
@@ -426,11 +428,11 @@ class TestFiltering:
         assert len(lengths) == 1
 
     @given(
-        component=sb_st.bids_components(max_values=4, restrict_patterns=True),
+        component=sb_st.expandables(max_values=4, restrict_patterns=True),
         data=st.data(),
     )
     def test_all_columns_found_in_original_zip_list(
-        self, component: BidsComponent, data: st.DataObject
+        self, component: Expandable, data: st.DataObject
     ):
         filter_dict = self.get_filter_dict(data, component, allow_extra_filters=True)
         filtered = component.filter(**filter_dict)
@@ -439,22 +441,22 @@ class TestFiltering:
             assert col in cols
 
     @given(
-        component=sb_st.bids_components(max_values=4, restrict_patterns=True),
+        component=sb_st.expandables(max_values=4, restrict_patterns=True),
         data=st.data(),
     )
     def test_all_entities_remain_after_filtering(
-        self, component: BidsComponent, data: st.DataObject
+        self, component: Expandable, data: st.DataObject
     ):
         filter_dict = self.get_filter_dict(data, component, allow_extra_filters=True)
         filtered = component.filter(**filter_dict)
         assert set(component.zip_lists) == set(filtered.zip_lists)
 
     @given(
-        component=sb_st.bids_components(max_values=4, restrict_patterns=True),
+        component=sb_st.expandables(max_values=4, restrict_patterns=True),
         data=st.data(),
     )
     def test_no_columns_that_should_be_present_are_missing(
-        self, component: BidsComponent, data: st.DataObject
+        self, component: Expandable, data: st.DataObject
     ):
         filter_dict = self.get_filter_dict(data, component)
         filtered = component.filter(**filter_dict)

--- a/snakebids/tests/test_datasets.py
+++ b/snakebids/tests/test_datasets.py
@@ -18,17 +18,11 @@ from snakebids.core.construct_bids import bids
 from snakebids.core.datasets import BidsComponent, BidsDataset
 from snakebids.exceptions import DuplicateComponentError
 from snakebids.tests import strategies as sb_st
-from snakebids.tests.helpers import (
-    entity_to_wildcard,
-    expand_zip_list,
-    get_bids_path,
-    get_zip_list,
-    setify,
-)
+from snakebids.tests.helpers import expand_zip_list, get_bids_path, get_zip_list, setify
 from snakebids.types import ZipList
 from snakebids.utils import sb_itertools as sb_it
 from snakebids.utils.snakemake_io import glob_wildcards
-from snakebids.utils.utils import BidsEntity, zip_list_eq
+from snakebids.utils.utils import BidsEntity, get_wildcard_dict, zip_list_eq
 
 
 def test_multiple_components_cannot_have_same_name():
@@ -303,7 +297,7 @@ class TestBidsComponentExpand:
         )
         path_tpl = bids(
             **component.wildcards,
-            **entity_to_wildcard(wildcards),
+            **get_wildcard_dict(wildcards),
         )
         wcard_dict = dict(zip(wildcards, values))
         zlist = expand_zip_list(component.zip_lists, wcard_dict)
@@ -346,7 +340,7 @@ class TestBidsComponentExpand:
         ),
     )
     def test_partial_expansion(self, component: BidsComponent, wildcard: str):
-        path_tpl = bids(**component.wildcards, **entity_to_wildcard(wildcard))
+        path_tpl = bids(**component.wildcards, **get_wildcard_dict(wildcard))
         paths = component.expand(path_tpl, allow_missing=True)
         for path in paths:
             assert re.search(r"\{.+\}", path)
@@ -360,7 +354,7 @@ class TestBidsComponentExpand:
         ),
     )
     def test_prevent_partial_expansion(self, component: BidsComponent, wildcard: str):
-        path_tpl = bids(**component.wildcards, **entity_to_wildcard(wildcard))
+        path_tpl = bids(**component.wildcards, **get_wildcard_dict(wildcard))
         with pytest.raises(WildcardError):
             component.expand(path_tpl)
 

--- a/snakebids/tests/test_datasets.py
+++ b/snakebids/tests/test_datasets.py
@@ -415,6 +415,12 @@ class TestFiltering:
             )
         return filter_dict
 
+    def filter_iter(self, filters: dict[str, str | list[str]]):
+        return {
+            key: iter(val) if isinstance(val, list) else val
+            for key, val in filters.items()
+        }
+
     @given(
         component=sb_st.bids_components(max_values=4, restrict_patterns=True),
         data=st.data(),
@@ -423,7 +429,7 @@ class TestFiltering:
         self, component: Expandable, data: st.DataObject
     ):
         filter_dict = self.get_filter_dict(data, component)
-        filtered = component.filter(**filter_dict)
+        filtered = component.filter(**self.filter_iter(filter_dict))
         for filt in filter_dict:
             for val in filtered.zip_lists[filt]:
                 assert val in filter_dict[filt]
@@ -436,7 +442,7 @@ class TestFiltering:
         self, component: Expandable, data: st.DataObject
     ):
         filter_dict = self.get_filter_dict(data, component)
-        filtered = component.filter(**filter_dict)
+        filtered = component.filter(**self.filter_iter(filter_dict))
         lengths: set[int] = set()
         for row in filtered.zip_lists.values():
             lengths.add(len(row))
@@ -450,7 +456,7 @@ class TestFiltering:
         self, component: Expandable, data: st.DataObject
     ):
         filter_dict = self.get_filter_dict(data, component, allow_extra_filters=True)
-        filtered = component.filter(**filter_dict)
+        filtered = component.filter(**self.filter_iter(filter_dict))
         cols = set(zip(*component.zip_lists.values()))
         for col in zip(*filtered.zip_lists.values()):
             assert col in cols
@@ -463,7 +469,7 @@ class TestFiltering:
         self, component: Expandable, data: st.DataObject
     ):
         filter_dict = self.get_filter_dict(data, component, allow_extra_filters=True)
-        filtered = component.filter(**filter_dict)
+        filtered = component.filter(**self.filter_iter(filter_dict))
         assert set(component.zip_lists) == set(filtered.zip_lists)
 
     @given(
@@ -471,10 +477,12 @@ class TestFiltering:
         data=st.data(),
     )
     def test_no_columns_that_should_be_present_are_missing(
-        self, component: Expandable, data: st.DataObject
+        self,
+        component: Expandable,
+        data: st.DataObject,
     ):
         filter_dict = self.get_filter_dict(data, component)
-        filtered = component.filter(**filter_dict)
+        filtered = component.filter(**self.filter_iter(filter_dict))
         keys = list(component.zip_lists)
         cols = set(zip(*component.zip_lists.values()))
         result = set(zip(*filtered.zip_lists.values()))

--- a/snakebids/tests/test_datasets.py
+++ b/snakebids/tests/test_datasets.py
@@ -160,7 +160,7 @@ class TestBidsComponentProperties:
     def test_input_lists_derives_from_zip_lists(
         self, data: st.DataObject, min_size: int
     ):
-        input_lists = data.draw(sb_st.bids_input_lists(min_size, max_size=5))
+        input_lists = data.draw(sb_st.bids_input_lists(min_size=min_size, max_size=5))
 
         # Due to the product, we can delete some of the combinations and still
         # regenerate our input_lists

--- a/snakebids/tests/test_datasets.py
+++ b/snakebids/tests/test_datasets.py
@@ -256,8 +256,7 @@ def _get_novel_path(prefix: str, component: Expandable):
 class TestExpandables:
     @given(
         component=sb_st.expandables(
-            restrict_patterns=True,
-            blacklist_entities=["extension"],
+            restrict_patterns=True, unique=True, blacklist_entities=["extension"]
         ),
         wildcards=st.lists(
             st.text(string.ascii_letters, min_size=1, max_size=10).filter(
@@ -330,6 +329,12 @@ class TestExpandables:
         with pytest.raises(WildcardError):
             component.expand(path_tpl)
 
+    @given(component=sb_st.expandables(restrict_patterns=True, path_safe=True))
+    def test_expand_deduplicates_paths(self, component: Expandable):
+        path_tpl = bids(**get_wildcard_dict(component.zip_lists))
+        paths = component.expand(path_tpl)
+        assert len(paths) == len(set(paths))
+
 
 class TestBidsComponentExpand:
     """
@@ -348,6 +353,7 @@ class TestBidsComponentExpand:
             blacklist_entities=["extension"],
             restrict_patterns=True,
             extra_entities=False,
+            unique=True,
         )
     )
     def test_expand_with_no_args_returns_initial_paths(self, component: BidsComponent):

--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -1038,6 +1038,8 @@ def test_generate_inputs(dataset: BidsDataset, bids_fs: Path, fakefs_tmpdir: Pat
 def test_when_all_custom_paths_no_layout_indexed(
     dataset: BidsDataset, bids_fs: Path, fakefs_tmpdir: Path, mocker: MockerFixture
 ):
+    # Need to reset mocker at beginning because hypothesis may call this function
+    # multiple times
     mocker.stopall()
     root = tempfile.mkdtemp(dir=fakefs_tmpdir)
     rooted = BidsDataset.from_iterable(

--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -146,7 +146,7 @@ class TestFilterBools:
             HealthCheck.too_slow,
         ],
     )
-    @given(dataset=sb_st.datasets())
+    @given(dataset=sb_st.datasets(unique=True))
     def test_entity_excluded_when_filter_false(
         self, tmpdir: Path, dataset: BidsDataset
     ):
@@ -226,7 +226,7 @@ class TestFilterBools:
             HealthCheck.too_slow,
         ],
     )
-    @given(dataset=sb_st.datasets())
+    @given(dataset=sb_st.datasets(unique=True))
     def test_entity_excluded_when_filter_true(self, tmpdir: Path, dataset: BidsDataset):
         root = tempfile.mkdtemp(dir=tmpdir)
         create_dataset(root, dataset)
@@ -1025,7 +1025,7 @@ def test_all_custom_paths(count: int):
         HealthCheck.too_slow,
     ],
 )
-@given(dataset=sb_st.datasets())
+@given(dataset=sb_st.datasets(unique=True))
 def test_generate_inputs(dataset: BidsDataset, bids_fs: Path, fakefs_tmpdir: Path):
     root = tempfile.mkdtemp(dir=fakefs_tmpdir)
     rooted = BidsDataset.from_iterable(
@@ -1040,7 +1040,7 @@ def test_generate_inputs(dataset: BidsDataset, bids_fs: Path, fakefs_tmpdir: Pat
 # The content of the dataset is irrelevant to this test, so one example suffices
 # but can't use extension because the custom path won't glob properly
 @settings(max_examples=1, suppress_health_check=[HealthCheck.function_scoped_fixture])
-@given(dataset=sb_st.datasets_one_comp(blacklist_entities=["extension"]))
+@given(dataset=sb_st.datasets_one_comp(blacklist_entities=["extension"], unique=True))
 def test_when_all_custom_paths_no_layout_indexed(
     dataset: BidsDataset, bids_fs: Path, fakefs_tmpdir: Path, mocker: MockerFixture
 ):

--- a/snakebids/tests/test_utils.py
+++ b/snakebids/tests/test_utils.py
@@ -106,22 +106,12 @@ class TestMultiselectDict:
             assert selected[key] is dicts[key]
 
     @given(dicts=sb_st.multiselect_dicts(st.text(), sb_st.everything()), data=st.data())
-    def test_all_requested_items_received(
+    def test_all_requested_items_received_and_no_others(
         self, dicts: MultiSelectDict[str, Any], data: st.DataObject
     ):
         selectors = self.get_selectors(data, dicts)
         selected = dicts[selectors]
-        for selector in selectors:
-            assert selector in selected
-
-    @given(dicts=sb_st.multiselect_dicts(st.text(), sb_st.everything()), data=st.data())
-    def test_no_extra_items_given(
-        self, dicts: MultiSelectDict[str, Any], data: st.DataObject
-    ):
-        selectors = self.get_selectors(data, dicts)
-        selected = dicts[selectors]
-        for selector in selected:
-            assert selector in selectors
+        assert set(selectors) == set(selected)
 
     @given(
         dicts=sb_st.multiselect_dicts(st.text(), sb_st.everything(), min_size=1),

--- a/snakebids/tests/test_utils.py
+++ b/snakebids/tests/test_utils.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import operator as op
 import re
+import string
+import sys
 from typing import Any
 
 import more_itertools as itx
@@ -10,7 +12,7 @@ from hypothesis import assume, given
 from hypothesis import strategies as st
 
 import snakebids.tests.strategies as sb_st
-from snakebids.utils.utils import MultiSelectDict, matches_any
+from snakebids.utils.utils import ImmutableList, MultiSelectDict, matches_any
 
 
 class TestMatchesAny:
@@ -154,3 +156,163 @@ class TestMultiselectDict:
         # Using the itx method for uniqueness to avoid calculating unique values in the
         # test in the same way as the source code
         assert tuple(dicts[selectors]) == tuple(itx.unique_everseen(selectors))
+
+
+class TestImmutableListsAreEquivalentToTuples:
+    @given(st.lists(sb_st.everything()))
+    def test_they_are_not_tuples(self, items: list[Any]):
+        iml = ImmutableList(items)
+        assert not isinstance(iml, tuple)
+
+    @given(st.lists(sb_st.partially_ordered(), min_size=1), st.data())
+    def test_contains_items(self, items: list[Any], data: st.DataObject):
+        iml = ImmutableList(items)
+        sample = data.draw(st.sampled_from(items))
+        assert sample in iml
+
+    @given(st.lists(sb_st.hashables()))
+    def test_is_hashable(self, items: list[Any]):
+        iml = ImmutableList(items)
+        assert hash(iml) == hash(tuple(items))
+
+    @given(st.lists(sb_st.everything()))
+    def test_is_iterable(self, items: list[Any]):
+        i = 0
+        iml = ImmutableList(items)
+        _iter = iter(iml)
+        while True:
+            try:
+                val = next(_iter)
+                assert val is items[i]
+                i += 1
+            except StopIteration:
+                break
+        assert i == len(items)
+
+    @given(st.lists(sb_st.everything()))
+    def test_is_reversable(self, items: list[Any]):
+        i = 0
+        iml = ImmutableList(items)
+        _iter = reversed(iml)
+        while True:
+            try:
+                val = next(_iter)
+                i += 1
+                assert val is items[-i]
+            except StopIteration:
+                break
+        assert i == len(items)
+
+    @given(st.lists(sb_st.everything()))
+    def test_has_length(self, items: list[Any]):
+        iml = ImmutableList(items)
+        assert len(iml) == len(items)
+
+    @given(st.lists(sb_st.everything(), min_size=1), st.data())
+    def test_supports_getting(self, items: list[Any], data: st.DataObject):
+        iml = ImmutableList(items)
+        index = data.draw(st.integers(min_value=0, max_value=len(items) - 1))
+        assert iml[index] is items[index]
+
+    @given(st.lists(sb_st.everything()), st.data())
+    def test_supports_slicing(self, items: list[Any], data: st.DataObject):
+        iml = ImmutableList(items)
+        _slice = data.draw(st.slices(len(items)))
+        for i, item in enumerate(iml[_slice]):
+            assert item is items[_slice][i]
+
+    @given(st.lists(st.integers()), st.lists(st.integers()))
+    def test_supports_comparisons(self, items1: list[Any], items2: list[Any]):
+        iml1 = ImmutableList(items1)
+        iml2 = ImmutableList(items2)
+        tup1 = tuple(items1)
+        tup2 = tuple(items2)
+        if tup1 == tup2:
+            assert iml1 == iml2
+            assert iml1 == tup2
+            assert tup1 == iml2
+        if tup1 >= tup2:
+            assert iml1 >= iml2
+            assert iml1 >= tup2
+            assert tup1 >= iml2
+        if tup1 > tup2:
+            assert iml1 > iml2
+            assert iml1 > tup2
+            assert tup1 > iml2
+        if tup1 < tup2:
+            assert iml1 < iml2
+            assert iml1 < tup2
+            assert tup1 < iml2
+        if tup1 <= tup2:
+            assert iml1 <= iml2
+            assert iml1 <= tup2
+            assert tup1 <= iml2
+
+    @given(st.lists(sb_st.partially_ordered()), st.lists(sb_st.partially_ordered()))
+    def test_supports_equality(self, items1: list[Any], items2: list[Any]):
+        iml1 = ImmutableList(items1)
+        iml2 = ImmutableList(items2)
+        tup1 = tuple(items1)
+        tup2 = tuple(items2)
+        if tup1 == tup2:
+            assert iml1 == iml2
+            assert iml1 == tup2
+            assert tup1 == iml2
+
+    @given(st.lists(sb_st.partially_ordered()))
+    def test_equal_items_are_equal(self, items: list[Any]):
+        iml1 = ImmutableList(items)
+        iml2 = ImmutableList(items)
+        tup1 = tuple(items)
+        tup2 = tuple(items)
+        assert iml1 == iml2
+        assert iml1 == tup2
+        assert tup1 == iml2
+
+    @given(st.lists(sb_st.everything()))
+    def test_supports_addition(self, items: list[Any]):
+        iml = ImmutableList(items)
+        assert iml + iml == tuple(items) + tuple(items)
+
+    @given(
+        st.lists(sb_st.everything(), max_size=10),
+        st.integers(min_value=-5, max_value=5),
+    )
+    def test_supports_multiplication(self, items: list[Any], value: int):
+        iml = ImmutableList(items)
+        assert iml * value == tuple(items) * value
+        assert value * iml == value * tuple(items)
+        assert value * iml == iml * value
+
+    @given(st.lists(sb_st.partially_ordered(), min_size=1), st.data())
+    def test_supports_count(self, items: list[Any], data: st.DataObject):
+        iml = ImmutableList(items)
+        sample = data.draw(st.sampled_from(items))
+        assert iml.count(sample) == items.count(sample)
+
+    @given(st.lists(sb_st.partially_ordered(), min_size=1), st.data())
+    def test_supports_index(self, items: list[Any], data: st.DataObject):
+        iml = ImmutableList(items)
+        _slice = data.draw(st.slices(len(items)))
+        assume(len(items[_slice]))
+        assume(_slice.step is None or _slice.step > 0)
+        sample = data.draw(st.sampled_from(items[_slice]))
+        start = 0 if _slice.start is None else _slice.start
+        stop = sys.maxsize if _slice.stop is None else _slice.stop
+        assert iml.index(sample, start, stop) == items.index(sample, start, stop)
+
+    @given(st.lists(sb_st.everything()), sb_st.everything())
+    def test_cannot_be_mutated(self, items: list[Any], value: Any):
+        iml = ImmutableList(items)
+        with pytest.raises(TypeError):
+            iml[len(iml)] = value  # type: ignore
+
+    @given(st.lists(st.text(string.printable)))
+    def test_repr(self, items: list[Any]):
+        iml = ImmutableList(items)
+        assert repr(iml) == f"ImmutableList({items})"
+
+    @given(st.lists(sb_st.everything()))
+    def test_bool(self, items: list[Any]):
+        iml = ImmutableList(items)
+        assert bool(iml) == bool(items)

--- a/snakebids/types.py
+++ b/snakebids/types.py
@@ -2,9 +2,17 @@ from __future__ import annotations
 
 from collections.abc import Hashable
 from enum import Enum
-from typing import Dict, Generic, List, Mapping, Sequence
+from pathlib import Path
+from typing import Dict, Generic, Iterable, List, Mapping, Sequence
 
-from typing_extensions import TYPE_CHECKING, Protocol, TypeAlias, TypedDict, TypeVar
+from typing_extensions import (
+    TYPE_CHECKING,
+    Protocol,
+    Self,
+    TypeAlias,
+    TypedDict,
+    TypeVar,
+)
 
 _T_contra = TypeVar("_T_contra", contravariant=True)
 _S_co = TypeVar("_S_co", covariant=True)
@@ -49,6 +57,30 @@ class InputConfig(TypedDict, total=False):
 
 class BinaryOperator(Protocol, Generic[_T_contra, _S_co]):
     def __call__(self, __first: _T_contra, __second: _T_contra) -> _S_co:
+        ...
+
+
+class Expandable(Protocol):
+    """Protocol represents objects that hold an entity table and can expand over a path
+
+    Includes BidsComponent, BidsPartialComponent, and BidsComponentRow
+    """
+
+    @property
+    def zip_lists(self) -> ZipList:
+        ...
+
+    def expand(
+        self,
+        paths: Iterable[Path | str] | Path | str,
+        allow_missing: bool = False,
+        **wildcards: str | Iterable[str],
+    ) -> list[str]:
+        ...
+
+    def filter(
+        self, *, regex_search: bool = False, **filters: str | Sequence[str]
+    ) -> Self:
         ...
 
 

--- a/snakebids/types.py
+++ b/snakebids/types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Hashable
 from enum import Enum
 from pathlib import Path
-from typing import Dict, Generic, Iterable, List, Mapping, Sequence
+from typing import Dict, Generic, Iterable, List, Mapping, Sequence, overload
 
 from typing_extensions import (
     TYPE_CHECKING,
@@ -81,6 +81,21 @@ class Expandable(Protocol):
     def filter(
         self, *, regex_search: bool = False, **filters: str | Sequence[str]
     ) -> Self:
+        ...
+
+
+_K_contra = TypeVar("_K_contra", bound="str", contravariant=True)
+_V_co = TypeVar("_V_co", covariant=True)
+_Valt_co = TypeVar("_Valt_co", covariant=True)
+
+
+class MultiSelectable(Protocol, Generic[_K_contra, _V_co, _Valt_co]):
+    @overload
+    def __getitem__(self, __key: _K_contra) -> _V_co:
+        ...
+
+    @overload
+    def __getitem__(self, __key: tuple[_K_contra, ...]) -> _Valt_co:
         ...
 
 

--- a/snakebids/types.py
+++ b/snakebids/types.py
@@ -72,7 +72,7 @@ class Expandable(Protocol):
 
     def expand(
         self,
-        paths: Iterable[Path | str] | Path | str,
+        __paths: Iterable[Path | str] | Path | str,
         allow_missing: bool = False,
         **wildcards: str | Iterable[str],
     ) -> list[str]:

--- a/snakebids/utils/utils.py
+++ b/snakebids/utils/utils.py
@@ -404,7 +404,7 @@ def zip_list_eq(__first: types.ZipListLike, __second: types.ZipListLike):
     first_items = get_values(__first)
     second_items = get_values(__second)
 
-    return set(zip(*first_items)) == set(zip(*second_items))
+    return sorted(zip(*first_items)) == sorted(zip(*second_items))
 
 
 def get_first_dir(path: str) -> str:

--- a/snakebids/utils/utils.py
+++ b/snakebids/utils/utils.py
@@ -519,3 +519,8 @@ class ImmutableList(Sequence[_T_co], Generic[_T_co]):
         self, value: Any, start: SupportsIndex = 0, stop: SupportsIndex = sys.maxsize
     ) -> int:
         return self._data.index(value, start, stop)
+
+
+def get_wildcard_dict(__entities: str | Iterable[str]) -> dict[str, str]:
+    """Turn entity strings into wildcard dicts as {"entity": "{entity}"}"""
+    return {entity: f"{{{entity}}}" for entity in itx.always_iterable(__entities)}

--- a/snakebids/utils/utils.py
+++ b/snakebids/utils/utils.py
@@ -429,6 +429,20 @@ _T_co = TypeVar("_T_co", covariant=True)
 
 
 class ImmutableList(Sequence[_T_co], Generic[_T_co]):
+    """Subclassable tuple equivalent
+
+    Mimics a tuple in every way, but readily supports subclassing. Data is stored on a
+    private attribute ``_data``. Subclasses must not override this attribute. To avoid
+    accidental modification, subclasses should avoid interacting with ``_data``, using
+    the relevant ``super()`` calls to access internal data instead (e.g. use
+    ``super().__getitem__(index)`` rather than ``self._data[index]``).
+
+    Unlike tuples, only a single type parameter is supported. In other words,
+    ``ImmutableList`` cannot be specified via type hints as a fixed length sequence
+    containing heterogenous items. A tuple specified as ``tuple[str, int, str]`` would
+    be specified as ``ImmutableList[str | int]``
+    """
+
     def __init__(self, __iterable: Iterable[_T_co] = tuple()):
         self._data = tuple(__iterable)
 


### PR DESCRIPTION
Resolves #243.

For a play-by-play of what I did, the commits are quite detailed and fairly well organized.

For a high level overview:

## The new classes

`BidsComponent` is conceived of as a multi-selectable `dict` (sort of... actually right now only `__getitem__` is implemented). If a tuple of entities is selected, you get back a `BidsPartialComponent` which has a `ZipList` but no `path` or `name`. `BidsComponent` is actually just a subclass of `BidsPartialComponent`. 

If a single entity is selected from `BidsComponent` (or `BidsPartialComponent`), you get a `BidsComponentRow`. This represents a single entity and its values, and it's implemented as a `ImmutableList` (sort of a `UserTuple`). It has the `wildcards` and `entities` properties, but instead of returning dicts, they directly return the `{str}` or `['list', 'of', 'values']` associated with the entity. This is to ensure symmetry between the following access modes:

```py
inputs['bold']['subject'].wildcards == inputs['bold'].wildcards['subject']
```

Note that the preferred style would still be `inputs['bold'].wildcards['subject']`, so this aspect of the new implementation is largely for consistency and to make everything more fail-proof.

On the other hand, `BidsComponentRow.zip_lists` *does* still return a dict mapping the one entity to its ordered entity list. This break in symmetry is motivated by the new `Expandable` protocol I established:

`Expandable` classes have an `expand` method, a `filter` method, and a `zip_lists` property or attribute. The signatures of these items must be as found in `BidsPartialComponent`. Thus, `zip_lists` in `BidsComponentRow` needs to return a dict in order to meet the protocol. In return, we're able to cleanly test all of three of the current classes using the exact same test code.

Furthermore, because `BidsComponentRow` is already implemented as a list with immediate access to the values, any call from the user to a symmetrically defined `zip_lists` would be completely redundant. It would give only a less powerful version of the list-like object the user already has.

## The documentation

I broke off a bit from our completely autogenerated documentation in the api section in order to prioritize the overview of `BidsComponent`. `BidsPartialComponent` is really mostly a repeat of `BidsComponent`, so none of it's members are shown, just an extended docstring overview. `BidsComponentRow` is rather different, so it's displayed in full.

I also moved the `input_*` legacy properties into a dropdown box. I suppose we could technically deprecate them, but they don't really do any harm and dropping them would completely prevent older workflows from upgrading (unlike `BidsDataset.wildcards` etc, which probably never had much buy-in). This way we can document them and keep them, but out of the way.

## Deduplication

I decided that `zip_list` deduplication should *not* be performed immediately when getting subcomponents and rows. This is both for simplicity, and to ensure that indexing remains consistent and clear as capabilities become more complex. So the only deduplication to be performed will be done in the `expand` method (since it unambiguously doesn't make sense for `expand` to return multiple identical paths)

## Design Question

* I stored the name of the entity in `BidsComponentRow` as `.entity`. The name is rather close to the `.entities` property, which returns something completely different (the `.entities` name doesn't make sense in isolation, but does if you consider the whole picture). So should we store `.entity` as something else?


## TBD

- [x] Add `zip_list` deduplication to the `expand` methods