### PR TITLE
Fix `--filter_{input_type}`

### DIFF
--- a/snakebids/cli.py
+++ b/snakebids/cli.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 import re
 from collections.abc import Sequence
-from typing import Any, Iterable, Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional, TypeVar, overload
 
 import attr
 import snakemake
@@ -315,9 +315,20 @@ def _make_underscore_dash_aliases(name: str) -> set[str]:
     return {name}
 
 
-def _resolve_path(
-    path_candidate: Sequence["os.PathLike[str] | str"] | "os.PathLike[str]" | str,
-) -> Any:
+T = TypeVar("T")
+
+
+@overload
+def _resolve_path(path_candidate: Sequence[T]) -> list[T]:
+    ...
+
+
+@overload
+def _resolve_path(path_candidate: T) -> T:
+    ...
+
+
+def _resolve_path(path_candidate: Any) -> Any:
     """Helper function to resolve any paths or list
     of paths it's passed. Otherwise, returns the argument
     unchanged.

--- a/snakebids/cli.py
+++ b/snakebids/cli.py
@@ -5,7 +5,7 @@ import logging
 import pathlib
 import re
 from collections.abc import Sequence
-from typing import Any, Iterable, Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional, TypeVar, overload
 
 import attr
 import snakemake
@@ -314,6 +314,19 @@ def _make_underscore_dash_aliases(name: str) -> set[str]:
     return {name}
 
 
+_T = TypeVar("_T")
+
+
+@overload
+def _resolve_path(path_candidate: Sequence[Any]) -> "list[Any]":
+    ...
+
+
+@overload
+def _resolve_path(path_candidate: _T) -> _T:
+    ...
+
+
 def _resolve_path(path_candidate: Any) -> Any:
     """Helper function to resolve any paths or list
     of paths it's passed. Otherwise, returns the argument
@@ -333,9 +346,9 @@ def _resolve_path(path_candidate: Any) -> Any:
 
     if isinstance(path_candidate, Sequence) and not isinstance(path_candidate, str):
         return [
-            _resolve_path(p)
+            _resolve_path(p)  # type: ignore[reportUnknownArgumentType]
             for p in path_candidate  # type: ignore[reportUnknownVariableType]
-        ]  # type: ignore[reportUnknownArgumentType]
+        ]
 
     if isinstance(path_candidate, Path):
         return Path(path_candidate).resolve()

--- a/snakebids/cli.py
+++ b/snakebids/cli.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 import argparse
 import logging
-import os
 import pathlib
 import re
 from collections.abc import Sequence
-from typing import Any, Iterable, Mapping, Optional, TypeVar, overload
+from typing import Any, Iterable, Mapping, Optional
 
 import attr
 import snakemake
@@ -315,19 +314,6 @@ def _make_underscore_dash_aliases(name: str) -> set[str]:
     return {name}
 
 
-T = TypeVar("T")
-
-
-@overload
-def _resolve_path(path_candidate: Sequence[T]) -> list[T]:
-    ...
-
-
-@overload
-def _resolve_path(path_candidate: T) -> T:
-    ...
-
-
 def _resolve_path(path_candidate: Any) -> Any:
     """Helper function to resolve any paths or list
     of paths it's passed. Otherwise, returns the argument
@@ -346,9 +332,12 @@ def _resolve_path(path_candidate: Any) -> Any:
     """
 
     if isinstance(path_candidate, Sequence) and not isinstance(path_candidate, str):
-        return [_resolve_path(p) for p in path_candidate]
+        return [
+            _resolve_path(p)
+            for p in path_candidate  # type: ignore[reportUnknownVariableType]
+        ]  # type: ignore[reportUnknownArgumentType]
 
-    if isinstance(path_candidate, os.PathLike):
+    if isinstance(path_candidate, Path):
         return Path(path_candidate).resolve()
 
     return path_candidate

--- a/snakebids/cli.py
+++ b/snakebids/cli.py
@@ -316,7 +316,7 @@ def _make_underscore_dash_aliases(name: str) -> set[str]:
 
 
 def _resolve_path(
-    path_candidate: Iterable["os.PathLike[str] | str"] | "os.PathLike[str]" | str,
+    path_candidate: Sequence["os.PathLike[str] | str"] | "os.PathLike[str]" | str,
 ) -> Any:
     """Helper function to resolve any paths or list
     of paths it's passed. Otherwise, returns the argument
@@ -334,7 +334,7 @@ def _resolve_path(
         Otherwise, the argument unchanged.
     """
 
-    if isinstance(path_candidate, Iterable) and not isinstance(path_candidate, str):
+    if isinstance(path_candidate, Sequence) and not isinstance(path_candidate, str):
         return [_resolve_path(p) for p in path_candidate]
 
     if isinstance(path_candidate, os.PathLike):

--- a/snakebids/tests/test_cli.py
+++ b/snakebids/tests/test_cli.py
@@ -55,6 +55,13 @@ class TestResolvePath:
         resolved = {key: _resolve_path(value) for key, value in arg_dict.items()}
         assert resolved == arg_dict_copy
 
+    def test_filter_dict(self, arg_dict: dict[str, dict[str, str]]):
+        filter_dict = {"test_key": "test_value"}
+        arg_dict["filter_test"] = filter_dict
+        arg_dict_copy = copy.deepcopy(arg_dict)
+        resolved = {key: _resolve_path(value) for key, value in arg_dict.items()}
+        assert resolved == arg_dict_copy
+
 
 class TestAddDynamicArgs:
     mock_args_special = ["--derivatives", "path/to/nowhere"]

--- a/snakebids/tests/test_cli.py
+++ b/snakebids/tests/test_cli.py
@@ -6,7 +6,7 @@ from argparse import ArgumentParser, Namespace
 from collections.abc import Sequence
 from os import PathLike
 from pathlib import Path
-from typing import Iterable, Mapping
+from typing import Mapping
 
 import pytest
 from pytest_mock.plugin import MockerFixture
@@ -24,9 +24,7 @@ from .mock.config import parse_args, pybids_inputs
 @pytest.fixture
 def parser():
     p = create_parser()
-    add_dynamic_args(
-        p, copy.deepcopy(parse_args), copy.deepcopy(pybids_inputs)
-    )
+    add_dynamic_args(p, copy.deepcopy(parse_args), copy.deepcopy(pybids_inputs))
     return p
 
 
@@ -44,9 +42,7 @@ class TestResolvePath:
         self, arg_dict: Mapping[str, str | Sequence[str]]
     ):
         arg_dict_copy = copy.deepcopy(arg_dict)
-        resolved = {
-            key: _resolve_path(value) for key, value in arg_dict.items()
-        }
+        resolved = {key: _resolve_path(value) for key, value in arg_dict.items()}
         assert resolved == arg_dict_copy
 
     def test_resolves_all_paths(
@@ -55,12 +51,8 @@ class TestResolvePath:
         derivative_paths = [Path("path/to/deriv1"), Path("path/to/deriv2")]
         arg_dict["--derivatives"] = derivative_paths
         arg_dict_copy = copy.deepcopy(arg_dict)
-        arg_dict_copy["--derivatives"] = [
-            p.resolve() for p in derivative_paths
-        ]
-        resolved = {
-            key: _resolve_path(value) for key, value in arg_dict.items()
-        }
+        arg_dict_copy["--derivatives"] = [p.resolve() for p in derivative_paths]
+        resolved = {key: _resolve_path(value) for key, value in arg_dict.items()}
         assert resolved == arg_dict_copy
 
 
@@ -103,17 +95,13 @@ class TestAddDynamicArgs:
         with pytest.raises(TypeError):
             add_dynamic_args(create_parser(), parse_args_copy, pybids_inputs)
 
-    def test_resolves_paths(
-        self, parser: ArgumentParser, mocker: MockerFixture
-    ):
+    def test_resolves_paths(self, parser: ArgumentParser, mocker: MockerFixture):
         mocker.patch.object(sys, "argv", self.mock_all_args)
         args = parse_snakebids_args(parser).args_dict
         assert args["derivatives"][0] == Path.cwd() / "path/to/nowhere"
 
 
-def test_dash_syntax_in_config_cli_args(
-    parser: ArgumentParser, mocker: MockerFixture
-):
+def test_dash_syntax_in_config_cli_args(parser: ArgumentParser, mocker: MockerFixture):
     mocker.patch.object(
         sys,
         "argv",

--- a/snakebids/tests/test_cli.py
+++ b/snakebids/tests/test_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import sys
 from argparse import ArgumentParser, Namespace
+from collections.abc import Sequence
 from os import PathLike
 from pathlib import Path
 from typing import Iterable, Mapping
@@ -23,7 +24,9 @@ from .mock.config import parse_args, pybids_inputs
 @pytest.fixture
 def parser():
     p = create_parser()
-    add_dynamic_args(p, copy.deepcopy(parse_args), copy.deepcopy(pybids_inputs))
+    add_dynamic_args(
+        p, copy.deepcopy(parse_args), copy.deepcopy(pybids_inputs)
+    )
     return p
 
 
@@ -38,20 +41,26 @@ class TestResolvePath:
         }
 
     def test_does_not_change_dict_without_paths(
-        self, arg_dict: Mapping[str, str | Iterable[str]]
+        self, arg_dict: Mapping[str, str | Sequence[str]]
     ):
         arg_dict_copy = copy.deepcopy(arg_dict)
-        resolved = {key: _resolve_path(value) for key, value in arg_dict.items()}
+        resolved = {
+            key: _resolve_path(value) for key, value in arg_dict.items()
+        }
         assert resolved == arg_dict_copy
 
     def test_resolves_all_paths(
-        self, arg_dict: dict[str, str | Path | Iterable[str | Path]]
+        self, arg_dict: dict[str, str | Path | Sequence[str | Path]]
     ):
         derivative_paths = [Path("path/to/deriv1"), Path("path/to/deriv2")]
         arg_dict["--derivatives"] = derivative_paths
         arg_dict_copy = copy.deepcopy(arg_dict)
-        arg_dict_copy["--derivatives"] = [p.resolve() for p in derivative_paths]
-        resolved = {key: _resolve_path(value) for key, value in arg_dict.items()}
+        arg_dict_copy["--derivatives"] = [
+            p.resolve() for p in derivative_paths
+        ]
+        resolved = {
+            key: _resolve_path(value) for key, value in arg_dict.items()
+        }
         assert resolved == arg_dict_copy
 
 
@@ -94,13 +103,17 @@ class TestAddDynamicArgs:
         with pytest.raises(TypeError):
             add_dynamic_args(create_parser(), parse_args_copy, pybids_inputs)
 
-    def test_resolves_paths(self, parser: ArgumentParser, mocker: MockerFixture):
+    def test_resolves_paths(
+        self, parser: ArgumentParser, mocker: MockerFixture
+    ):
         mocker.patch.object(sys, "argv", self.mock_all_args)
         args = parse_snakebids_args(parser).args_dict
         assert args["derivatives"][0] == Path.cwd() / "path/to/nowhere"
 
 
-def test_dash_syntax_in_config_cli_args(parser: ArgumentParser, mocker: MockerFixture):
+def test_dash_syntax_in_config_cli_args(
+    parser: ArgumentParser, mocker: MockerFixture
+):
     mocker.patch.object(
         sys,
         "argv",


### PR DESCRIPTION
## Proposed changes

Resolves #287. Noticed that the `args_dict` only returned the `key` in a list instead of a dict, and originates from changes to `_resolve_path`. The `--filter_{input_type}` calls were read in correctly. I think this bug may have been introduced when we changed some of the `List` types to `Iterable`/`Sequence`. In any case this issue was resolved by changing `Iterable` to `Sequence` in `_resolve_path`.

My :brain: can't come up with a coherent explanation why this bug was happening, but I think it probably has something to do with trying to recursively resolve the "path" in the dict when the condition `isInstance(path_candidate, Iterable)` was met in the original code.

As noted in #287, we should probably add testing for this (#94?). In the meantime, it would be good to get this patched and released to get this functionality working again.

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [x] Changes pass the unit tests
- [x] I have included necessary documentation or comments (as necessary)
- [x] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.