### PR TITLE
Ignore deadlines for hypothesis tests on pr

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,6 +117,8 @@ jobs:
     - name: Install library
       run: poetry install --no-interaction
     - name: Test with pytest
+      env:
+        HYPOTHESIS_PROFILE: pr
       run: |
         poetry run pytest --doctest-modules --ignore=docs --ignore=snakebids/project_template --benchmark-disable
 

--- a/snakebids/tests/conftest.py
+++ b/snakebids/tests/conftest.py
@@ -1,12 +1,24 @@
 from __future__ import annotations
 
+import os
 import tempfile
 from pathlib import Path
 from typing import Optional
 
 import bids.layout
 import pytest
+from hypothesis import settings
 from pyfakefs.fake_filesystem import FakeFilesystem
+
+## Hypothesis profiles
+
+# github-actions tends to have flaky runtimes, likely due to temporary slowdowns in the
+# runner, so just disable deadlines
+settings.register_profile("pr", deadline=None)
+
+settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "default"))
+
+# Fixtures
 
 
 @pytest.fixture

--- a/snakebids/tests/test_printing.py
+++ b/snakebids/tests/test_printing.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import pyparsing as pp
-from hypothesis import assume, given, settings
+from hypothesis import assume, given
 from hypothesis import strategies as st
 
 import snakebids.tests.strategies as sb_st
@@ -23,9 +23,6 @@ def zip_list_parser() -> pp.ParserElement:
     return pp.Suppress("{") + pp.Group(row)[1, ...] + pp.Suppress("}")
 
 
-# Test is often flaky for some reason on Github Actions. No known particular reason
-# why this test should take long (it should be quite fast), so just disable the deadline
-@settings(deadline=None)
 @given(zip_list=sb_st.zip_lists(max_entities=1, restrict_patterns=True))
 def test_ellipses_appears_when_maxwidth_too_short(zip_list: ZipList):
     width = len(format_zip_lists(zip_list, tabstop=0).splitlines()[1])

--- a/snakebids/tests/test_utils.py
+++ b/snakebids/tests/test_utils.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import more_itertools as itx
 import pytest
-from hypothesis import assume, given, settings
+from hypothesis import assume, given
 from hypothesis import strategies as st
 
 import snakebids.tests.strategies as sb_st
@@ -126,9 +126,6 @@ class TestMultiselectDict:
         selector = data.draw(st.sampled_from(list(dicts)))
         assert not isinstance(dicts[selector], MultiSelectDict)
 
-    # This test has been flaky on github actions. No reason it should be long, so
-    # just disable deadline
-    @settings(deadline=None)
     @given(
         dicts=sb_st.multiselect_dicts(st.text(), sb_st.everything(), min_size=1),
         data=st.data(),


### PR DESCRIPTION
Been having a lot of issues with flaky tests lately, entirely due to timing inconsistencies. The failing tests are not complicated, there's not particular reason for long runtimes, and it probably has more to do with the github actions runner being slow (here's another source corroborating this https://datascience.blog.wzb.eu/2022/03/04/continuous-integration-testing-with-github-actions-using-tox-and-hypothesis/). So I'd like to just disable test deadlines altogether on for PRs: playing whack-a-mole one test a time is too much work.