### PR TITLE
Boolean CLI filters

### DIFF
--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -20,6 +20,7 @@ from snakebids.cli import (
     parse_snakebids_args,
 )
 from snakebids.exceptions import ConfigError, RunError
+from snakebids.types import OptionalFilter
 from snakebids.utils.output import write_config_file  # type: ignore
 from snakebids.utils.output import prepare_bidsapp_output, write_output_mode
 
@@ -253,7 +254,12 @@ def update_config(config: dict[str, Any], snakebids_args: SnakebidsArgs) -> None
     for input_type in pybids_inputs.keys():
         arg_filter_dict = args[f"filter_{input_type}"]
         if arg_filter_dict is not None:
-            pybids_inputs[input_type]["filters"].update(arg_filter_dict)
+            pybids_inputs[input_type].setdefault("filters", {})
+            for entity, filter_ in arg_filter_dict.items():
+                if filter_ == OptionalFilter:
+                    pybids_inputs[input_type]["filters"].pop(entity, None)
+                else:
+                    pybids_inputs[input_type]["filters"][entity] = filter_
         del args[f"filter_{input_type}"]
 
     # add cmdline defined wildcards from the list:
@@ -261,6 +267,7 @@ def update_config(config: dict[str, Any], snakebids_args: SnakebidsArgs) -> None
     for input_type in pybids_inputs.keys():
         wildcards_list = args[f"wildcards_{input_type}"]
         if wildcards_list is not None:
+            pybids_inputs[input_type].setdefault("wildcards", [])
             pybids_inputs[input_type]["wildcards"] += wildcards_list
         del args[f"wildcards_{input_type}"]
 

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -256,7 +256,7 @@ def update_config(config: dict[str, Any], snakebids_args: SnakebidsArgs) -> None
         if arg_filter_dict is not None:
             pybids_inputs[input_type].setdefault("filters", {})
             for entity, filter_ in arg_filter_dict.items():
-                if filter_ == OptionalFilter:
+                if filter_ is OptionalFilter:
                     pybids_inputs[input_type]["filters"].pop(entity, None)
                 else:
                     pybids_inputs[input_type]["filters"][entity] = filter_

--- a/snakebids/cli.py
+++ b/snakebids/cli.py
@@ -37,22 +37,21 @@ class FilterParse(argparse.Action):
             return
 
         for pair in values:
-            match_ = re.fullmatch("([a-zA-Z0-9]+).(OPTIONAL|REQUIRED|NONE)", pair)
-            if match_:
-                key = match_.group(1)
-                spec = match_.group(2)
-                if spec == "OPTIONAL":
-                    value = OptionalFilter
-                elif spec == "REQUIRED":
-                    value = True
-                elif spec == "NONE":
-                    value = False
-                else:
-                    # Should never happen
-                    raise MisspecifiedCliFilterError(pair)
-            elif "=" in pair:
+            if "=" in pair:
                 # split it into key and value
                 key, value = pair.split("=", 1)
+            elif ":" in pair:
+                key, spec = pair.split(":", 1)
+                spec = spec.lower()
+                if spec == "optional":
+                    value = OptionalFilter
+                elif spec in ["required", "any"]:
+                    value = True
+                elif spec == "none":
+                    value = False
+                else:
+                    # The flag isn't recognized
+                    raise MisspecifiedCliFilterError(pair)
             else:
                 raise MisspecifiedCliFilterError(pair)
 
@@ -233,8 +232,8 @@ def add_dynamic_args(
     filter_opts = parser.add_argument_group(
         "BIDS FILTERS",
         "Filters to customize PyBIDS get() as key=value pairs, or as "
-        "key.{REQUIRED|OPTIONAL|NONE}, to enforce the presence or absence of values for"
-        "that key.",
+        "key:{REQUIRED|OPTIONAL|NONE} (case-insensitive), to enforce the presence or "
+        "absence of values for that key.",
     )
 
     for input_type in pybids_inputs.keys():

--- a/snakebids/cli.py
+++ b/snakebids/cli.py
@@ -52,7 +52,7 @@ class FilterParse(argparse.Action):
                     raise MisspecifiedCliFilterError(pair)
             elif "=" in pair:
                 # split it into key and value
-                key, value = pair.split("=")
+                key, value = pair.split("=", 1)
             else:
                 raise MisspecifiedCliFilterError(pair)
 

--- a/snakebids/cli.py
+++ b/snakebids/cli.py
@@ -21,8 +21,8 @@ Path = pathlib.Path
 logger = logging.Logger(__name__)
 
 
-class KeyValue(argparse.Action):
-    """Class for accepting key=value pairs in argparse"""
+class FilterParse(argparse.Action):
+    """Class for parsing CLI filters in argparse"""
 
     # Constructor calling
     def __call__(
@@ -232,7 +232,9 @@ def add_dynamic_args(
     # create filter parsers, one for each input_type
     filter_opts = parser.add_argument_group(
         "BIDS FILTERS",
-        "Filters to customize PyBIDS get() as key=value pairs",
+        "Filters to customize PyBIDS get() as key=value pairs, or as "
+        "key.{REQUIRED|OPTIONAL|NONE}, to enforce the presence or absence of values for"
+        "that key.",
     )
 
     for input_type in pybids_inputs.keys():
@@ -243,7 +245,7 @@ def add_dynamic_args(
         filter_opts.add_argument(
             *argnames,
             nargs="+",
-            action=KeyValue,
+            action=FilterParse,
             help=f"(default: {' '.join(arglist_default)})",
         )
 

--- a/snakebids/exceptions.py
+++ b/snakebids/exceptions.py
@@ -35,3 +35,14 @@ class DuplicateComponentError(Exception):
             "names. The following duplicate names were found: "
             f"{self.duplicated_names_str}."
         )
+
+
+class MisspecifiedCliFilterError(Exception):
+    """Raised when a magic CLI filter cannot be parsed."""
+
+    def __init__(self, misspecified_filter: str):
+        super().__init__(
+            "The following filter provided by the CLI could not be parsed: "
+            f"{misspecified_filter}. Filters must be of the form "
+            "{entity}={filter} or {entity}.{REQUIRED|OPTIONAL|NONE}."
+        )

--- a/snakebids/exceptions.py
+++ b/snakebids/exceptions.py
@@ -44,5 +44,5 @@ class MisspecifiedCliFilterError(Exception):
         super().__init__(
             "The following filter provided by the CLI could not be parsed: "
             f"{misspecified_filter}. Filters must be of the form "
-            "{entity}={filter} or {entity}.{REQUIRED|OPTIONAL|NONE}."
+            "{entity}={filter} or {entity}:{REQUIRED|OPTIONAL|NONE} (case-insensitive)."
         )

--- a/snakebids/tests/helpers.py
+++ b/snakebids/tests/helpers.py
@@ -208,7 +208,7 @@ def reindex_dataset(
     return generate_inputs(root, config)
 
 
-def allow_tmpdir(__callable: _T) -> _T:
+def allow_function_scoped(__callable: _T) -> _T:
     """Allow function_scoped fixtures in hypothesis tests
 
     This is primarily useful for using tmpdirs, hence, the name

--- a/snakebids/tests/test_app.py
+++ b/snakebids/tests/test_app.py
@@ -73,6 +73,33 @@ class TestUpdateConfig:
                 == Path(input_config["custom_path"]).resolve()
             )
 
+    @given(
+        inputs_config=sb_st.inputs_configs(),
+    )
+    def test_magic_optional_filter(
+        self,
+        inputs_config: InputsConfig,
+    ):
+        config_copy: dict[str, Any] = copy.deepcopy(config)
+        config_copy["bids_dir"] = "root"
+        config_copy["output_dir"] = "app"
+        config_copy["pybids_inputs"] = inputs_config
+        args = SnakebidsArgs(
+            force=False,
+            outputdir=Path("app"),
+            snakemake_args=[],
+            args_dict={
+                f"filter_{input_}": [
+                    f"{entity}.OPTIONAL" for entity in value.get("filters", [])
+                ]
+                for input_, value in inputs_config.items()
+            },
+        )
+        update_config(config_copy, args)
+        inputs_config = config_copy["pybids_inputs"]
+        for input_config in inputs_config.values():
+            assert len(input_config.get("filters", {})) == 0
+
 
 class TestRunSnakemake:
     valid_chars = st.characters(

--- a/snakebids/tests/test_app.py
+++ b/snakebids/tests/test_app.py
@@ -40,14 +40,18 @@ def app(mocker: MockerFixture):
 class TestUpdateConfig:
     @given(
         input_config=sb_st.input_configs(),
+        drop_wildcards=st.booleans(),
     )
     def test_magic_args(
         self,
         input_config: InputConfig,
+        drop_wildcards: bool,
     ):
         config_copy: dict[str, Any] = copy.deepcopy(config)
         config_copy["bids_dir"] = "root"
         config_copy["output_dir"] = "app"
+        if drop_wildcards:
+            del config_copy["pybids_inputs"]["bold"]["wildcards"]
         args = SnakebidsArgs(
             force=False,
             outputdir=Path("app"),

--- a/snakebids/tests/test_app.py
+++ b/snakebids/tests/test_app.py
@@ -14,7 +14,7 @@ from pytest_mock.plugin import MockerFixture
 from snakebids.app import update_config
 from snakebids.cli import SnakebidsArgs
 from snakebids.tests import strategies as sb_st
-from snakebids.types import InputConfig, InputsConfig
+from snakebids.types import InputConfig, InputsConfig, OptionalFilter
 
 from .. import app as sn_app
 from ..app import SnakeBidsApp
@@ -84,16 +84,20 @@ class TestUpdateConfig:
         config_copy["bids_dir"] = "root"
         config_copy["output_dir"] = "app"
         config_copy["pybids_inputs"] = inputs_config
+        args_dict: dict[str, Any] = {
+            f"filter_{input_}": {
+                entity: OptionalFilter for entity in value.get("filters", [])
+            }
+            for input_, value in inputs_config.items()
+        }
+        for input_ in inputs_config:
+            args_dict[f"wildcards_{input_}"] = None
+            args_dict[f"path_{input_}"] = None
         args = SnakebidsArgs(
             force=False,
             outputdir=Path("app"),
             snakemake_args=[],
-            args_dict={
-                f"filter_{input_}": [
-                    f"{entity}.OPTIONAL" for entity in value.get("filters", [])
-                ]
-                for input_, value in inputs_config.items()
-            },
+            args_dict=args_dict,
         )
         update_config(config_copy, args)
         inputs_config = config_copy["pybids_inputs"]

--- a/snakebids/tests/test_cli.py
+++ b/snakebids/tests/test_cli.py
@@ -20,7 +20,7 @@ from snakebids.cli import (
     parse_snakebids_args,
 )
 from snakebids.tests import strategies as sb_st
-from snakebids.types import InputsConfig
+from snakebids.types import InputsConfig, OptionalFilter
 
 from .mock.config import parse_args, pybids_inputs
 
@@ -106,6 +106,57 @@ class TestAddDynamicArgs:
             assert isinstance(args.args_dict[f"path_{key_identifier}"], str)
             assert isinstance(args.args_dict[f"filter_{key_identifier}"], dict)
             assert isinstance(args.args_dict[f"wildcards_{key_identifier}"], list)
+
+    @given(pybids_inputs=sb_st.inputs_configs())
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_required_filters(self, mocker: MockerFixture, pybids_inputs: InputsConfig):
+        p = create_parser()
+        add_dynamic_args(p, copy.deepcopy(parse_args), pybids_inputs)
+        magic_filters = list(
+            it.chain.from_iterable(
+                [[f"--filter-{key}", "entity.REQUIRED"] for key in pybids_inputs]
+            )
+        )
+        mocker.patch.object(sys, "argv", self.mock_all_args + magic_filters)
+
+        args = parse_snakebids_args(p)
+        for key in pybids_inputs:
+            key_identifier = key.replace("-", "_")
+            assert args.args_dict[f"filter_{key_identifier}"] is True
+
+    @given(pybids_inputs=sb_st.inputs_configs())
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_optional_filters(self, mocker: MockerFixture, pybids_inputs: InputsConfig):
+        p = create_parser()
+        add_dynamic_args(p, copy.deepcopy(parse_args), pybids_inputs)
+        magic_filters = list(
+            it.chain.from_iterable(
+                [[f"--filter-{key}", "entity.OPTIONAL"] for key in pybids_inputs]
+            )
+        )
+        mocker.patch.object(sys, "argv", self.mock_all_args + magic_filters)
+
+        args = parse_snakebids_args(p)
+        for key in pybids_inputs:
+            key_identifier = key.replace("-", "_")
+            assert args.args_dict[f"filter_{key_identifier}"] is OptionalFilter
+
+    @given(pybids_inputs=sb_st.inputs_configs())
+    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    def test_none_filters(self, mocker: MockerFixture, pybids_inputs: InputsConfig):
+        p = create_parser()
+        add_dynamic_args(p, copy.deepcopy(parse_args), pybids_inputs)
+        magic_filters = list(
+            it.chain.from_iterable(
+                [[f"--filter-{key}", "entity.NONE"] for key in pybids_inputs]
+            )
+        )
+        mocker.patch.object(sys, "argv", self.mock_all_args + magic_filters)
+
+        args = parse_snakebids_args(p)
+        for key in pybids_inputs:
+            key_identifier = key.replace("-", "_")
+            assert args.args_dict[f"filter_{key_identifier}"] is False
 
     def test_fails_if_missing_arguments(
         self, parser: ArgumentParser, mocker: MockerFixture

--- a/snakebids/tests/test_cli.py
+++ b/snakebids/tests/test_cli.py
@@ -122,7 +122,7 @@ class TestAddDynamicArgs:
         args = parse_snakebids_args(p)
         for key in pybids_inputs:
             key_identifier = key.replace("-", "_")
-            assert args.args_dict[f"filter_{key_identifier}"] is True
+            assert args.args_dict[f"filter_{key_identifier}"]["entity"] is True
 
     @given(pybids_inputs=sb_st.inputs_configs())
     @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
@@ -139,7 +139,9 @@ class TestAddDynamicArgs:
         args = parse_snakebids_args(p)
         for key in pybids_inputs:
             key_identifier = key.replace("-", "_")
-            assert args.args_dict[f"filter_{key_identifier}"] is OptionalFilter
+            assert (
+                args.args_dict[f"filter_{key_identifier}"]["entity"] is OptionalFilter
+            )
 
     @given(pybids_inputs=sb_st.inputs_configs())
     @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
@@ -156,7 +158,7 @@ class TestAddDynamicArgs:
         args = parse_snakebids_args(p)
         for key in pybids_inputs:
             key_identifier = key.replace("-", "_")
-            assert args.args_dict[f"filter_{key_identifier}"] is False
+            assert args.args_dict[f"filter_{key_identifier}"]["entity"] is False
 
     def test_fails_if_missing_arguments(
         self, parser: ArgumentParser, mocker: MockerFixture

--- a/snakebids/tests/test_cli.py
+++ b/snakebids/tests/test_cli.py
@@ -12,7 +12,7 @@ from typing import Mapping
 
 import hypothesis.strategies as st
 import pytest
-from hypothesis import HealthCheck, given, settings
+from hypothesis import given
 from pytest_mock.plugin import MockerFixture
 
 from snakebids.cli import (
@@ -22,6 +22,7 @@ from snakebids.cli import (
     parse_snakebids_args,
 )
 from snakebids.tests import strategies as sb_st
+from snakebids.tests.helpers import allow_function_scoped
 from snakebids.types import InputsConfig, OptionalFilter
 
 from .mock.config import parse_args, pybids_inputs
@@ -80,7 +81,7 @@ class TestAddDynamicArgs:
     mock_all_args = mock_basic_args + mock_args_special
 
     @given(sb_st.inputs_configs())
-    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @allow_function_scoped
     def test_dynamic_inputs(self, mocker: MockerFixture, pybids_inputs: InputsConfig):
         p = create_parser()
         add_dynamic_args(p, copy.deepcopy(parse_args), pybids_inputs)
@@ -115,7 +116,7 @@ class TestAddDynamicArgs:
             re.compile(r"(?:required)|(?:any)", re.IGNORECASE), fullmatch=True
         ),
     )
-    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @allow_function_scoped
     def test_required_filters(
         self, mocker: MockerFixture, pybids_inputs: InputsConfig, flag: str
     ):
@@ -137,7 +138,7 @@ class TestAddDynamicArgs:
         pybids_inputs=sb_st.inputs_configs(),
         flag=st.from_regex(re.compile(r"optional", re.IGNORECASE), fullmatch=True),
     )
-    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @allow_function_scoped
     def test_optional_filters(
         self, mocker: MockerFixture, pybids_inputs: InputsConfig, flag: str
     ):
@@ -161,7 +162,7 @@ class TestAddDynamicArgs:
         pybids_inputs=sb_st.inputs_configs(),
         flag=st.from_regex(re.compile(r"none", re.IGNORECASE), fullmatch=True),
     )
-    @settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+    @allow_function_scoped
     def test_none_filters(
         self, mocker: MockerFixture, pybids_inputs: InputsConfig, flag: str
     ):

--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -47,7 +47,7 @@ from snakebids.exceptions import ConfigError, PybidsError, RunError
 from snakebids.tests import strategies as sb_st
 from snakebids.tests.helpers import (
     BidsListCompare,
-    allow_tmpdir,
+    allow_function_scoped,
     create_dataset,
     get_bids_path,
     get_zip_list,
@@ -474,7 +474,7 @@ class TestCustomPaths:
         test_path = self.generate_test_directory(entities, template, tmp_path)
         benchmark(_parse_custom_path, test_path)
 
-    @allow_tmpdir
+    @allow_function_scoped
     @given(path_entities=path_entities())
     def test_collects_all_paths_when_no_filters(
         self,

--- a/snakebids/types.py
+++ b/snakebids/types.py
@@ -98,6 +98,11 @@ index must correspond to the same path.
 
 
 class OptionalFilterType(Enum):
+    """Sentinel value for CLI OPTIONAL filtering.
+
+    This is necessary because None means no CLI filter was added.
+    """
+
     OptionalFilter = "OptionalFilter"
 
 

--- a/snakebids/types.py
+++ b/snakebids/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Hashable
+from enum import Enum
 from typing import Dict, Generic, List, Mapping, Sequence
 
 from typing_extensions import TYPE_CHECKING, Protocol, TypeAlias, TypedDict, TypeVar
@@ -94,3 +95,10 @@ Useful for typing functions that won't mutate the ZipList or use
 each :class:`~typing.Sequence` must be the same length, and values in each with the same
 index must correspond to the same path.
 """
+
+
+class OptionalFilterType(Enum):
+    OptionalFilter = "OptionalFilter"
+
+
+OptionalFilter = OptionalFilterType.OptionalFilter


### PR DESCRIPTION
## Proposed changes

Resolves #258. REQUIRED and NONE just set the `pybids_inputs` to `True` and `False`, respectively, and let Snakebids parse them as usual. OPTIONAL sets the relevant filter to a sentinel value that gets picked up and drops any existing filters.

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [x] Changes have been tested to ensure that fix is effective or that a feature works.
- [x] Changes pass the unit tests
- [x] I have included necessary documentation or comments (as necessary)
- [x] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.