### PR TITLE
Allow Booleans in filter lists

### DIFF
--- a/snakebids/core/input_generation.py
+++ b/snakebids/core/input_generation.py
@@ -15,7 +15,7 @@ import more_itertools as itx
 from bids import BIDSLayout, BIDSLayoutIndexer
 from bids.layout import BIDSFile, Query
 from snakemake.script import Snakemake
-from typing_extensions import Literal
+from typing_extensions import Literal, TypeAlias
 
 from snakebids.core.datasets import BidsComponent, BidsDataset, BidsDatasetDict
 from snakebids.core.filtering import filter_list
@@ -552,18 +552,30 @@ def _parse_bids_path(path: str, entities: Iterable[str]) -> tuple[str, dict[str,
 class _GetListsFromBidsSteps:
     input_name: str
 
+    FilterType: TypeAlias = "Mapping[str, str | bool | Sequence[str | bool]]"
+
+    def _get_invalid_filters(self, filters: FilterType):
+        for key, filts in filters.items():
+            try:
+                if True in filts or False in filts:  # type: ignore
+                    yield key, filts
+            except TypeError:
+                pass
+
     def prepare_bids_filters(
         self, filters: Mapping[str, str | bool | Sequence[str | bool]]
     ) -> dict[str, str | Query | list[str | Query]]:
         if sys.version_info < (3, 8):
-            for key, filts in filters.items():
-                filts_ = list(itx.always_iterable(filts))
-                if True in filts_ or False in filts_:
-                    raise ConfigError(
-                        "Booleans may not be included in filter lists in Python 3.7.x "
-                        "or lower. Please upgrade to Python 3.8.x or greater for this "
-                        f"feature.\n\tComponent: {self.input_name}\n\t{key}: {filts}"
-                    )
+            invalid_filters = list(self._get_invalid_filters(filters))
+            if invalid_filters:
+                msg = (
+                    f"Invalid filters in component: '{self.input_name}'. Booleans "
+                    "may not be included in filter lists in Python 3.7.x "
+                    "or lower. Please upgrade to Python 3.8.x or greater for this "
+                    f"feature. Invalid filters:\n\t"
+                ) + "\n\t".join(f"{key}: {val}" for key, val in invalid_filters)
+
+                raise ConfigError(msg)
             return {
                 key: Query.ANY if f is True else Query.NONE if f is False else f
                 for key, f in filters.items()

--- a/snakebids/core/input_generation.py
+++ b/snakebids/core/input_generation.py
@@ -607,9 +607,13 @@ def _get_lists_from_bids(
         zip_lists: dict[str, list[str]] = defaultdict(list)
         paths: set[str] = set()
         pybids_filters = {
-            key: Query.ANY if val is True else Query.NONE if val is False else val
-            for key, val in component.get("filters", {}).items()
+            key: [
+                Query.ANY if f is True else Query.NONE if f is False else f
+                for f in itx.always_iterable(filts)
+            ]
+            for key, filts in component.get("filters", {}).items()
         }
+
         try:
             matching_files: Iterable[BIDSFile] = bids_layout.get(
                 regex_search=regex_search, **pybids_filters, **filters

--- a/snakebids/core/input_generation.py
+++ b/snakebids/core/input_generation.py
@@ -5,10 +5,12 @@ import json
 import logging
 import os
 import re
+import sys
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Generator, Iterable, Optional, Sequence, overload
+from typing import Any, Generator, Iterable, Mapping, Optional, Sequence, overload
 
+import attrs
 import more_itertools as itx
 from bids import BIDSLayout, BIDSLayoutIndexer
 from bids.layout import BIDSFile, Query
@@ -546,6 +548,50 @@ def _parse_bids_path(path: str, entities: Iterable[str]) -> tuple[str, dict[str,
     return "".join(new_path), wildcard_values
 
 
+@attrs.define
+class _GetListsFromBidsSteps:
+    input_name: str
+
+    def prepare_bids_filters(
+        self, filters: Mapping[str, str | bool | Sequence[str | bool]]
+    ) -> dict[str, str | Query | list[str | Query]]:
+        if sys.version_info < (3, 8):
+            for key, filts in filters.items():
+                filts_ = list(itx.always_iterable(filts))
+                if True in filts_ or False in filts_:
+                    raise ConfigError(
+                        "Booleans may not be included in filter lists in Python 3.7.x "
+                        "or lower. Please upgrade to Python 3.8.x or greater for this "
+                        f"feature.\n\tComponent: {self.input_name}\n\t{key}: {filts}"
+                    )
+            return {
+                key: Query.ANY if f is True else Query.NONE if f is False else f
+                for key, f in filters.items()
+            }  # type: ignore
+        return {
+            key: [
+                Query.ANY if f is True else Query.NONE if f is False else f
+                for f in itx.always_iterable(filts)
+            ]
+            for key, filts in filters.items()
+        }
+
+    def get_matching_files(
+        self,
+        bids_layout: BIDSLayout,
+        regex_search: bool,
+        filters: Mapping[str, str | Query | Sequence[str | Query]],
+    ) -> Iterable[BIDSFile]:
+        try:
+            return bids_layout.get(regex_search=regex_search, **filters)
+        except AttributeError as err:
+            raise PybidsError(
+                "Pybids has encountered a problem that Snakebids cannot handle. This "
+                "may indicate a missing or invalid dataset_description.json for this "
+                "dataset."
+            ) from err
+
+
 def _get_lists_from_bids(
     bids_layout: Optional[BIDSLayout],
     pybids_inputs: InputsConfig,
@@ -578,6 +624,7 @@ def _get_lists_from_bids(
         One BidsComponent is yielded for each modality described by ``pybids_inputs``.
     """
     for input_name in limit_to or list(pybids_inputs):
+        steps = _GetListsFromBidsSteps(input_name)
         _logger.debug("Grabbing inputs for %s...", input_name)
         component = pybids_inputs[input_name]
 
@@ -606,24 +653,11 @@ def _get_lists_from_bids(
 
         zip_lists: dict[str, list[str]] = defaultdict(list)
         paths: set[str] = set()
-        pybids_filters = {
-            key: [
-                Query.ANY if f is True else Query.NONE if f is False else f
-                for f in itx.always_iterable(filts)
-            ]
-            for key, filts in component.get("filters", {}).items()
-        }
+        pybids_filters = steps.prepare_bids_filters(component.get("filters", {}))
+        matching_files = steps.get_matching_files(
+            bids_layout, regex_search, {**pybids_filters, **filters}
+        )
 
-        try:
-            matching_files: Iterable[BIDSFile] = bids_layout.get(
-                regex_search=regex_search, **pybids_filters, **filters
-            )
-        except AttributeError as err:
-            raise PybidsError(
-                "Pybids has encountered a problem that Snakebids cannot handle. This "
-                "may indicate a missing or invalid dataset_description.json for this "
-                "dataset."
-            ) from err
         for img in matching_files:
             wildcards: list[str] = [
                 wildcard

--- a/snakebids/tests/helpers.py
+++ b/snakebids/tests/helpers.py
@@ -179,9 +179,7 @@ def create_dataset(root: str | Path, dataset: BidsDataset) -> None:
     touched: they will have no contents.
     """
     for component in dataset.values():
-        entities = list(component.zip_lists.keys())
-        for values in zip(*component.zip_lists.values()):
-            path = Path(root, component.path.format(**dict(zip(entities, values))))
+        for path in map(Path(root).joinpath, component.expand()):
             path.parent.mkdir(parents=True, exist_ok=True)
             path.touch()
 
@@ -194,7 +192,7 @@ def create_snakebids_config(dataset: BidsDataset) -> InputsConfig:
     return {
         comp.name: {
             "filters": {
-                BidsEntity.from_tag(entity).entity: comp.entities[entity]
+                BidsEntity.from_tag(entity).entity: list(comp.entities[entity])
                 if entity in comp.entities
                 else False
                 for entity in all_entities

--- a/snakebids/tests/strategies.py
+++ b/snakebids/tests/strategies.py
@@ -153,7 +153,11 @@ def input_configs(draw: st.DrawFn) -> InputConfig:
         st.one_of(
             st.dictionaries(
                 bids_entity().map(str),
-                st.one_of(st.booleans(), bids_value(), st.lists(bids_value())),
+                st.one_of(
+                    st.booleans(),
+                    bids_value(),
+                    st.lists(st.one_of(bids_value(), st.booleans())),
+                ),
             ),
             st.none(),
         )

--- a/snakebids/tests/strategies.py
+++ b/snakebids/tests/strategies.py
@@ -33,13 +33,22 @@ def bids_entity(
     *,
     blacklist_entities: Optional[Container[BidsEntity | str]] = None,
     whitelist_entities: Optional[Container[BidsEntity | str]] = None,
+    path_safe: bool = False,
 ) -> st.SearchStrategy[BidsEntity]:
+    blacklist = (
+        helpers.ContainerBag(
+            blacklist_entities if blacklist_entities is not None else set(),
+            {"datatype", "suffix", "extension"},
+        )
+        if path_safe
+        else blacklist_entities or set()
+    )
     return st.sampled_from(
         [
             BidsEntity(key)
             for key in valid_entities
             if key not in ["fmap", "scans"]
-            and key not in (blacklist_entities or [])
+            and key not in (blacklist)
             and (not whitelist_entities or key in whitelist_entities)
         ],
     )
@@ -246,13 +255,9 @@ def bids_component_row(  # noqa: PLR0913
 ) -> BidsComponentRow:
     entity = entity or draw(
         bids_entity(
-            blacklist_entities=helpers.ContainerBag(
-                blacklist_entities if blacklist_entities is not None else {},
-                {"datatype", "suffix", "extension"},
-            )
-            if path_safe
-            else blacklist_entities,
+            blacklist_entities=blacklist_entities,
             whitelist_entities=whitelist_entities,
+            path_safe=path_safe,
         )
     )
     values = draw(

--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -253,6 +253,11 @@ class TestFilterBools:
         data = generate_inputs(root, pybids_inputs)
         assert data == expected
 
+    @pytest.mark.skipif(
+        sys.version_info < (3, 8),
+        reason="Filter lists with booleans does not work on pybids versions available "
+        "to py37",
+    )
     @allow_function_scoped
     @given(
         template=sb_st.bids_components(
@@ -311,6 +316,36 @@ class TestFilterBools:
         result = generate_inputs(root, pybids_inputs)
         assert result == BidsDataset({"target": dataset["target"]})
 
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 8), reason="Just a compatability check for py37"
+    )
+    @given(
+        dataset=sb_st.datasets_one_comp(),
+        entity=sb_st.bids_entity(path_safe=True),
+    )
+    @allow_function_scoped
+    def test_filter_lists_with_bools_fail_on_py37(
+        self,
+        tmpdir: Path,
+        dataset: BidsDataset,
+        entity: BidsEntity,
+    ):
+        root = tempfile.mkdtemp(dir=tmpdir)
+        create_dataset(root, dataset)
+        pybids_inputs: InputsConfig = {
+            "template": {
+                "filters": {entity.entity: [False]},
+            }
+        }
+
+        with pytest.raises(ConfigError):
+            generate_inputs(root, pybids_inputs)
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 8),
+        reason="Filter lists with booleans does not work on pybids versions available "
+        "to py37",
+    )
     @allow_function_scoped
     @given(
         template=sb_st.bids_components(

--- a/snakebids/types.py
+++ b/snakebids/types.py
@@ -21,7 +21,7 @@ _S_co = TypeVar("_S_co", covariant=True)
 class InputConfig(TypedDict, total=False):
     """Configuration for a single bids component"""
 
-    filters: dict[str, str | bool | list[str]]
+    filters: dict[str, str | bool | list[str | bool]]
     """Filters to pass on to :class:`BIDSLayout.get() <bids.layout.BIDSLayout>`
 
     Each key refers to the name of an entity. Values may take the following forms:


### PR DESCRIPTION
Previously, we only checked if the entire filter was set to a boolean, not if one of the entries was a boolean. This fix allows us to filter datasets where an entity must either be absent or set to a specific value.