### PR TITLE
Fix mistaken comparison of BidsEntity to str sets

### DIFF
--- a/snakebids/tests/strategies.py
+++ b/snakebids/tests/strategies.py
@@ -81,7 +81,7 @@ def _filter_invalid_entity_lists(entities: Sequence[BidsEntity | str]):
             ("suffix" not in entities or "extension" in entities),
             # Cannot have paths with just datatype, just extension, or just datatype and
             # extension
-            set(entities)
+            set(map(str, entities))
             not in [
                 {"datatype"},
                 {"extension"},


### PR DESCRIPTION
The first part of fix got pushed to main directly by accident. This is an attempt at patching a mistake I made in the first push.