### PR TITLE
HOTFIX Fix pybidsdb path resolution

### DIFF
--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -176,14 +176,14 @@ class SnakeBidsApp:
         #    the snakefile folder
         # - Add info from args
         # - Set mode (bidsapp or workflow) and output_dir appropriately
+        update_config(self.config, self.args)
+
         self.config["snakemake_dir"] = self.snakemake_dir
         self.config["snakefile"] = self.snakefile_path
 
         # Update config with pybids settings
         self.config["pybidsdb_dir"] = self.args.pybidsdb_dir
         self.config["pybidsdb_reset"] = self.args.pybidsdb_reset
-
-        update_config(self.config, self.args)
 
         # First, handle outputs in snakebids_root or results folder
         try:

--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -144,7 +144,7 @@ class SnakeBidsApp:
     snakemake_dir: Path = attr.ib(converter=to_resolved_path)
     plugins: list[Callable[[SnakeBidsApp], None | SnakeBidsApp]] = attr.Factory(list)
     skip_parse_args: bool = False
-    parser: argparse.ArgumentParser = create_parser()
+    parser: argparse.ArgumentParser = attr.Factory(create_parser)
     configfile_path: Path = attr.Factory(
         _get_file_paths(CONFIGFILE_CHOICES, "config"), takes_self=True
     )

--- a/snakebids/tests/test_app.py
+++ b/snakebids/tests/test_app.py
@@ -248,6 +248,32 @@ class TestRunSnakemake:
             ]
         )
 
+    def test_pybidsdb_path_resolved(self, mocker: MockerFixture):
+        self.io_mocks(mocker)
+        mocker.patch.object(
+            sys,
+            "argv",
+            ["./run.sh", "input", "output", "participant", "--pybidsdb-dir", ".pybids"],
+        )
+
+        # Prepare app and initial config values
+        app = SnakeBidsApp(
+            Path("app"),
+            skip_parse_args=False,
+            snakefile_path=Path("Snakefile"),
+            configfile_path=Path("mock/config.yaml"),
+            config=copy.deepcopy(config),
+        )
+
+        # Prepare expected config
+        try:
+            app.run_snakemake()
+        except SystemExit as e:
+            print("System exited prematurely")
+            print(e)
+
+        assert app.config["pybidsdb_dir"] == Path(".pybids").resolve()
+
     def test_plugin_args(self, mocker: MockerFixture, app: SnakeBidsApp):
         """Test that plugins have access to args parsed from the CLI."""
         # Get mocks for all the io functions


### PR DESCRIPTION
Regression introduced in #296. `--pybidsdb_dir` was no longer automatically being resolved.

The resolved path was getting overwritten by the args_dict in SnakebidsArgs. This didn't happen previously because the resolved path was saved under a different name than the CLI parameter, but since resolving the names, the CLI parameter name overwrites the resolved name.

Fix by changing the order of update_config and the manual setting of the pybids path

## Proposed changes

Describe the changes implemented in this pull request. If the changes fix a bug or resolves a feature request, be sure to link the issue (and explain how the changes address the issue). Be sure to select a label describing the PR (e.g. maintenance).

## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you are unsure about any of the choices, don't hesitate to ask!

- [ ] Changes have been tested to ensure that fix is effective or that a feature works.
- [ ] Changes pass the unit tests
- [ ] I have included necessary documentation or comments (as necessary)
- [ ] Any dependent changes have been merged and published

## Notes
All PRs will undergo the unit testing before being reviewed. You may be requested to explain or make additional changes before the PR is accepted.