### PR TITLE
Fix version fetching in readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,9 +18,18 @@ formats:
   - pdf
 
 build:
-  os: 'ubuntu-20.04'
+  os: 'ubuntu-22.04'
   tools:
-    python: '3.10'
+    python: '3.11'
+  jobs:
+    post_checkout:
+      - (git fetch --tags) || exit 183
+    pre_install:
+      - git update-index --assume-unchanged docs/conf.py
+    pre_build:
+       - >
+        python -m sphinx -b linkcheck -D linkcheck_timeout=1 docs/
+          $READTHEDOCS_OUTPUT/linkcheck
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -26,10 +26,6 @@ build:
       - (git fetch --tags) || exit 183
     pre_install:
       - git update-index --assume-unchanged docs/conf.py
-    pre_build:
-       - >
-        python -m sphinx -b linkcheck -D linkcheck_timeout=1 docs/
-          $READTHEDOCS_OUTPUT/linkcheck
 
 python:
   install:


### PR DESCRIPTION
In stable builds, readthedocs is not currently fetching git tags, which we need for determining project version. So we're getting unhelpful versions at the top of our project documentation like `0.0.1.devxxx-blahblah`.

This is an attempt to fix this by adding some post_checkout steps

