### PR TITLE
Update dependencies and pyright version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1494,13 +1494,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "poethepoet"
-version = "0.21.1"
+version = "0.22.0"
 description = "A task runner that works well with poetry."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "poethepoet-0.21.1-py3-none-any.whl", hash = "sha256:c79b2aefc889c4490db9d64ecc1896db78700aa212b8c5f0bca4aee0395e7714"},
-    {file = "poethepoet-0.21.1.tar.gz", hash = "sha256:39d754f53714545a23cfc94b122deaf3548218b6e35b453c30973c5598719e9f"},
+    {file = "poethepoet-0.22.0-py3-none-any.whl", hash = "sha256:f654e52c19b7c689d5293ab6a065787b21f125884c0b367650292df4f3cb508c"},
+    {file = "poethepoet-0.22.0.tar.gz", hash = "sha256:659d7678fd8b349bd40941e3de7d6d386171dab3e7c8babcdcd8ead288c9ea47"},
 ]
 
 [package.dependencies]
@@ -1739,13 +1739,13 @@ files = [
 
 [[package]]
 name = "pyright"
-version = "1.1.311"
+version = "1.1.324"
 description = "Command line wrapper for pyright"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyright-1.1.311-py3-none-any.whl", hash = "sha256:04df30c6b31d05068effe5563411291c876f5e4221d0af225a267b61dce1ca85"},
-    {file = "pyright-1.1.311.tar.gz", hash = "sha256:554b555d3f770e8da2e76d6bb94e2ac63b3edc7dcd5fb8de202f9dd53e36689a"},
+    {file = "pyright-1.1.324-py3-none-any.whl", hash = "sha256:0edb712afbbad474e347de12ca1bd9368aa85d3365a1c7b795012e48e6a65111"},
+    {file = "pyright-1.1.324.tar.gz", hash = "sha256:0c48e3bca3d081bba0dddd0c1f075aaa965c59bba691f7b9bd9d73a98e44e0cf"},
 ]
 
 [package.dependencies]
@@ -2102,28 +2102,28 @@ files = [
 
 [[package]]
 name = "ruff"
-version = "0.0.280"
+version = "0.0.285"
 description = "An extremely fast Python linter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.0.280-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:48ed5aca381050a4e2f6d232db912d2e4e98e61648b513c350990c351125aaec"},
-    {file = "ruff-0.0.280-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:ef6ee3e429fd29d6a5ceed295809e376e6ece5b0f13c7e703efaf3d3bcb30b96"},
-    {file = "ruff-0.0.280-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d878370f7e9463ac40c253724229314ff6ebe4508cdb96cb536e1af4d5a9cd4f"},
-    {file = "ruff-0.0.280-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:83e8f372fa5627eeda5b83b5a9632d2f9c88fc6d78cead7e2a1f6fb05728d137"},
-    {file = "ruff-0.0.280-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7008fc6ca1df18b21fa98bdcfc711dad5f94d0fc3c11791f65e460c48ef27c82"},
-    {file = "ruff-0.0.280-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:fe7118c1eae3fda17ceb409629c7f3b5a22dffa7caf1f6796776936dca1fe653"},
-    {file = "ruff-0.0.280-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:37359cd67d2af8e09110a546507c302cbea11c66a52d2a9b6d841d465f9962d4"},
-    {file = "ruff-0.0.280-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd58af46b0221efb95966f1f0f7576df711cb53e50d2fdb0e83c2f33360116a4"},
-    {file = "ruff-0.0.280-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e7c15828d09f90e97bea8feefcd2907e8c8ce3a1f959c99f9b4b3469679f33c"},
-    {file = "ruff-0.0.280-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2dae8f2d9c44c5c49af01733c2f7956f808db682a4193180dedb29dd718d7bbe"},
-    {file = "ruff-0.0.280-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5f972567163a20fb8c2d6afc60c2ea5ef8b68d69505760a8bd0377de8984b4f6"},
-    {file = "ruff-0.0.280-py3-none-musllinux_1_2_i686.whl", hash = "sha256:8ffa7347ad11643f29de100977c055e47c988cd6d9f5f5ff83027600b11b9189"},
-    {file = "ruff-0.0.280-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7a37dab70114671d273f203268f6c3366c035fe0c8056614069e90a65e614bfc"},
-    {file = "ruff-0.0.280-py3-none-win32.whl", hash = "sha256:7784e3606352fcfb193f3cd22b2e2117c444cb879ef6609ec69deabd662b0763"},
-    {file = "ruff-0.0.280-py3-none-win_amd64.whl", hash = "sha256:4a7d52457b5dfcd3ab24b0b38eefaead8e2dca62b4fbf10de4cd0938cf20ce30"},
-    {file = "ruff-0.0.280-py3-none-win_arm64.whl", hash = "sha256:b7de5b8689575918e130e4384ed9f539ce91d067c0a332aedef6ca7188adac2d"},
-    {file = "ruff-0.0.280.tar.gz", hash = "sha256:581c43e4ac5e5a7117ad7da2120d960a4a99e68ec4021ec3cd47fe1cf78f8380"},
+    {file = "ruff-0.0.285-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:72a3a0936369b986b0e959f9090206ed3c18f9e5e439ea5b8e6867c6707aded5"},
+    {file = "ruff-0.0.285-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:0d9ab6ad16742eb78919e0fba09f914f042409df40ad63423c34bb20d350162a"},
+    {file = "ruff-0.0.285-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c48926156288b8ac005eb1db5e77c15e8a37309ae49d9fb6771d5cf5f777590"},
+    {file = "ruff-0.0.285-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1d2a60c102e7a5e147b58fc2cbea12a563c565383effc527c987ea2086a05742"},
+    {file = "ruff-0.0.285-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b02aae62f922d088bb01943e1dbd861688ada13d735b78b8348a7d90121fd292"},
+    {file = "ruff-0.0.285-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f572c4296d8c7ddd22c3204de4031965be524fdd1fdaaef273945932912b28c5"},
+    {file = "ruff-0.0.285-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:80effdf4fe69763d69eb4ab9443e186fd09e668b59fe70ba4b49f4c077d15a1b"},
+    {file = "ruff-0.0.285-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5977ce304da35c263f5e082901bd7ac0bd2be845a8fcfd1a29e4d6680cddb307"},
+    {file = "ruff-0.0.285-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72a087712d474fa17b915d7cb9ef807e1256182b12ddfafb105eb00aeee48d1a"},
+    {file = "ruff-0.0.285-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7ce67736cd8dfe97162d1e7adfc2d9a1bac0efb9aaaff32e4042c7cde079f54b"},
+    {file = "ruff-0.0.285-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5473a4c6cac34f583bff08c5f63b8def5599a0ea4dc96c0302fbd2cc0b3ecbad"},
+    {file = "ruff-0.0.285-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e6b1c961d608d373a032f047a20bf3c55ad05f56c32e7b96dcca0830a2a72348"},
+    {file = "ruff-0.0.285-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2933cc9631f453305399c7b8fb72b113ad76b49ae1d7103cc4afd3a423bed164"},
+    {file = "ruff-0.0.285-py3-none-win32.whl", hash = "sha256:770c5eb6376de024111443022cda534fb28980a9dd3b4abc83992a8770167ba6"},
+    {file = "ruff-0.0.285-py3-none-win_amd64.whl", hash = "sha256:a8c6ad6b9cd77489bf6d1510950cbbe47a843aa234adff0960bae64bd06c3b6d"},
+    {file = "ruff-0.0.285-py3-none-win_arm64.whl", hash = "sha256:de44fbc6c3b25fccee473ddf851416fd4e246fc6027b2197c395b1b3b3897921"},
+    {file = "ruff-0.0.285.tar.gz", hash = "sha256:45866048d1dcdcc80855998cb26c4b2b05881f9e043d2e3bfe1aa36d9a2e8f28"},
 ]
 
 [[package]]
@@ -2807,4 +2807,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.12"
-content-hash = "44427a5709ffd947b29761f65c99ea05a065a2267a2f8ebfc961d4ae208b5a03"
+content-hash = "d6bc4ca4c26ff0f36a6535221686ef48b8a064e2f1077dfe1fba51232a1b3e99"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ black = "^23.1.0"
 pytest = "^7.0.0"
 pytest-mock = "^3.7.0"
 isort = "^5.10.1"
-poethepoet = "^0.21.1"
+poethepoet = "^0.22.0"
 pre-commit = "^3.0.0"
 mkinit = "^1.0.0"
 hypothesis = "^6.34.1"
@@ -79,9 +79,9 @@ pyfakefs = "^5.1.0"
 pyparsing = "^3.0.9"
 # Version 1.1.312-1.1.315 have a false positive handling some nested function
 # calls
-pyright = ">=1.1.307,<1.1.312"
-ruff = "^0.0.280"
 pathvalidate = "^3.0.0"
+pyright = ">=1.1.324"
+ruff = "^0.0.285"
 
 [tool.poetry.scripts]
 snakebids = "snakebids.admin:main"

--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -269,6 +269,11 @@ class TestFilterBools:
         target = data.draw(sb_st.bids_value(entity.match))
         decoy = data.draw(sb_st.bids_value(entity.match))
         assume(target != decoy)
+        # This is a brute-force way of dealing with the fact that values for `run` are
+        # converted into int by pybids before querying. So just prevent the decoy from
+        # ever looking like the same number as target
+        if target.isdecimal() and decoy.isdecimal():
+            assume(int(target) != int(decoy))
         dataset = BidsDataset.from_iterable(
             [
                 attrs.evolve(

--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -602,7 +602,9 @@ class TestCustomPaths:
         test_path = self.generate_test_directory(entities, template, temp_dir)
 
         # Test with filters
-        result_filtered = MultiSelectDict(_parse_custom_path(test_path, **filters))
+        result_filtered = MultiSelectDict(
+            _parse_custom_path(test_path, regex_search=False, **filters)
+        )
         zip_lists = MultiSelectDict(
             {
                 # Start with empty lists for each key, otherwise keys will be missing

--- a/snakebids/tests/test_paths/test_bids.py
+++ b/snakebids/tests/test_paths/test_bids.py
@@ -7,7 +7,7 @@ from typing import Iterable
 
 import more_itertools as itx
 import pytest
-from hypothesis import assume, given
+from hypothesis import assume, example, given
 from hypothesis import strategies as st
 from pathvalidate import Platform, is_valid_filename, is_valid_filepath
 
@@ -144,11 +144,15 @@ def test_beginning_of_path_always_root(entities: dict[str, str], root: str):
     assert path[length] == os.path.sep
 
 
+@example(entities={"sub": "0"}, datatype=".", root="0")
 @given(entities=_bids_args(nonstandard=False), datatype=_values(), root=_roots())
 def test_bottom_directory_always_datatype(
     entities: dict[str, str], datatype: str, root: str
 ):
-    assert datatype == Path(bids(root=root, datatype=datatype, **entities)).parent.name
+    # use os.path functions so that datatype=="." is treated safely
+    assert datatype == os.path.basename(
+        os.path.dirname(bids(root=root, datatype=datatype, **entities))
+    )
 
 
 @given(entities=_bids_args(nonstandard=False), datatype=_values())

--- a/snakebids/types.py
+++ b/snakebids/types.py
@@ -76,13 +76,16 @@ class Expandable(Protocol):
         self,
         paths: Iterable[Path | str] | Path | str,
         /,
-        allow_missing: bool = False,
+        allow_missing: bool | str | Iterable[str] = False,
         **wildcards: str | Iterable[str],
     ) -> list[str]:
         ...
 
     def filter(
-        self, *, regex_search: bool = False, **filters: str | Sequence[str]
+        self,
+        *,
+        regex_search: bool | str | Iterable[str] = False,
+        **filters: str | Iterable[str],
     ) -> Self:
         ...
 

--- a/typings/bids/layout/layout.pyi
+++ b/typings/bids/layout/layout.pyi
@@ -6,7 +6,7 @@ from __future__ import annotations
 import enum
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 
 from bids import BIDSLayoutIndexer
 from bids.layout.models import BIDSFile, Entity
@@ -270,13 +270,13 @@ class BIDSLayout:
         ...
     def get(
         self,
-        return_type=...,
-        target=...,
-        scope=...,
+        # return_type=...,
+        # target=...,
+        # scope=...,
         regex_search: bool = ...,
-        absolute_paths=...,
-        invalid_filters=...,
-        **filters: str,
+        # absolute_paths=...,
+        # invalid_filters=...,
+        **filters: str | Query | Sequence[str | Query],
     ) -> list[BIDSFile]:
         """Retrieve files and/or metadata from the current Layout.
 

--- a/typings/snakemake/io.pyi
+++ b/typings/snakemake/io.pyi
@@ -284,6 +284,8 @@ def local(value):  # -> AnnotatedString | list[Unknown]:
 def expand(
     filepatterns: Sequence[Path | str] | Path | str,
     func: Callable[[Iterable[str]], Iterable[Iterable[str]]] | None = ...,
+    /,
+    *,
     allow_missing: bool | Sequence[str] | str = ...,
     **wildcards: Sequence[str] | str,
 ) -> list[str]:


### PR DESCRIPTION
Fix a number of type issues arising with latest pyright

Need to lock pyright to >=1.1.324 because previous versions have a false
positive bug

Some dict.get(..., {}) require laborious workarounds because the value
type of the dict is a TypedDict, which is different than a regular dict
and can't be constructed easily on the fly. The latest pyright version
uses the latest typeshed, which changed the inference rules to prevent
our previous "hack" from working. This situation will probably never
change.

Broadened the annotated types for some keyword args on functions
accepting both fixed and generic kwargs with differing types. The fixed
kwargs need to allow at least the same types as the generic args, or we
get type issues downstream. Use type validation to compensate
