### PR TITLE
Refactor filter_list to use RegexContainer

### DIFF
--- a/snakebids/tests/helpers.py
+++ b/snakebids/tests/helpers.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import (
     Any,
     Callable,
-    Container,
     Dict,
     Iterable,
     List,
@@ -282,23 +281,6 @@ def example_if(condition: bool, *args: Any, **kwargs: Any):
         return inner
 
     return identity
-
-
-class ContainerBag(Container[_T]):
-    """Container to hold other containers
-
-    Useful because list(Container) isn't guarenteed to work, so this lets us merge
-    Containers in a type safe way.
-    """
-
-    def __init__(self, *entries: Container[_T]):
-        self.entries = entries
-
-    def __contains__(self, x: object, /) -> bool:
-        for entry in self.entries:
-            if x in entry:
-                return True
-        return False
 
 
 class Benchmark(Protocol):

--- a/snakebids/tests/strategies.py
+++ b/snakebids/tests/strategies.py
@@ -19,7 +19,7 @@ from snakebids.core.datasets import (
 )
 from snakebids.tests import helpers
 from snakebids.types import Expandable, InputConfig, InputsConfig, ZipList
-from snakebids.utils.utils import BidsEntity, MultiSelectDict
+from snakebids.utils.utils import BidsEntity, ContainerBag, MultiSelectDict
 
 _Ex_co = TypeVar("_Ex_co", bound=str, covariant=True)
 _T = TypeVar("_T")
@@ -38,7 +38,7 @@ def bids_entity(
     whitelist_entities: Container[BidsEntity | str] | None = None,
     path_safe: bool = False,
 ) -> st.SearchStrategy[BidsEntity]:
-    blacklist = helpers.ContainerBag(
+    blacklist = ContainerBag(
         {"fmap", "scans"},
         blacklist_entities if blacklist_entities is not None else set(),
         {"datatype", "suffix", "extension"} if path_safe else set(),
@@ -114,7 +114,7 @@ def bids_path(
                 zip_lists(
                     max_values=1,
                     max_entities=2,
-                    blacklist_entities=helpers.ContainerBag(
+                    blacklist_entities=ContainerBag(
                         blacklist_entities if blacklist_entities is not None else [],
                         [BidsEntity.normalize(e) for e in entities],
                     ),

--- a/snakebids/tests/test_generate_inputs.py
+++ b/snakebids/tests/test_generate_inputs.py
@@ -328,6 +328,10 @@ class TestFilterBools:
         target = data.draw(sb_st.bids_value(entity.match))
         decoy = data.draw(sb_st.bids_value(entity.match))
         assume(target != decoy)
+        # See note in test_filter_works_when_false_in_list
+        if target.isdecimal() and decoy.isdecimal():
+            assume(int(target) != int(decoy))
+
         root = tempfile.mkdtemp(dir=tmpdir)
         dataset = BidsDataset.from_iterable(
             [

--- a/snakebids/tests/test_paths/test_bids.py
+++ b/snakebids/tests/test_paths/test_bids.py
@@ -240,7 +240,7 @@ def test_dir_entities_each_own_dir(entities: dict[str, str]):
 
 @given(
     entities=_bids_args(entities=HAS_DIR, nonstandard=False, custom=False),
-    root=_roots(),
+    root=_roots().filter(lambda s: s != "."),
 )
 def test_directories_in_correct_order(entities: dict[str, str], root: str):
     tags = _get_entity_tags(entities)

--- a/snakebids/tests/test_utils.py
+++ b/snakebids/tests/test_utils.py
@@ -15,6 +15,7 @@ import snakebids.tests.strategies as sb_st
 from snakebids.utils.utils import (
     ImmutableList,
     MultiSelectDict,
+    RegexContainer,
     get_wildcard_dict,
     matches_any,
 )
@@ -326,3 +327,25 @@ def test_get_wildcard_dict(zip_list: dict[str, str]):
     first = wildstr.format(**wildcards)
     second = first.format(**zip_list)
     assert set(second.split(".")) == set(zip_list.values())
+
+
+class TestRegexContainer:
+    DDWW = r"^\d{3}[a-zA-Z]{3}$"
+    bDDWW = rb"^\d{3}[a-zA-Z]{3}$"
+    WWDD = r"^[a-zA-Z]{3}\d{3}$"
+
+    @given(sample=st.from_regex(DDWW))
+    def test_str_matching_regex_are_contained(self, sample: str):
+        assert sample in RegexContainer(self.DDWW)
+
+    @given(sample=st.from_regex(bDDWW))
+    def test_bytes_matching_regex_are_contained(self, sample: bytes):
+        assert sample in RegexContainer(self.bDDWW)
+
+    @given(sample=st.from_regex(WWDD))
+    def test_str_not_matching_regex_excluded(self, sample: str):
+        assert sample not in RegexContainer(self.DDWW)
+
+    @given(sample=st.from_regex(bDDWW))
+    def test_container_specific_to_type(self, sample: str):
+        assert sample not in RegexContainer(self.DDWW)


### PR DESCRIPTION
The original intent of the PR was to add boolean support to `filter_list` so
that we could support boolean filters with custom paths, but I relealized after
some initial refactoring that such support doesn't really make any sense. So
now the PR has just the refactors:

This simplifies the filtering operation and will allow for more flexible
control of regex vs regular filtering in the future

RegexContainer is a container containing a regex expression. Strings are
"contained" if the "re.match" the expression

Move ContainerBag from test code to utils for use in filter_list
