### PR TITLE
Add deprecation mechanism to old pybidsdb vals 

### DIFF
--- a/snakebids/app.py
+++ b/snakebids/app.py
@@ -28,7 +28,7 @@ from snakebids.exceptions import ConfigError, RunError
 from snakebids.types import OptionalFilter
 from snakebids.utils.output import write_config_file  # type: ignore
 from snakebids.utils.output import prepare_bidsapp_output, write_output_mode
-from snakebids.utils.utils import to_resolved_path
+from snakebids.utils.utils import DEPRECATION_FLAG, to_resolved_path
 
 logger = logging.Logger(__name__)
 
@@ -184,6 +184,12 @@ class SnakeBidsApp:
         # Update config with pybids settings
         self.config["pybidsdb_dir"] = self.args.pybidsdb_dir
         self.config["pybidsdb_reset"] = self.args.pybidsdb_reset
+        self.config[
+            "pybids_db_dir"
+        ] = f"{DEPRECATION_FLAG}{self.args.pybidsdb_dir}{DEPRECATION_FLAG}"
+        self.config[
+            "pybids_db_reset"
+        ] = f"{DEPRECATION_FLAG}{int(self.args.pybidsdb_reset)}{DEPRECATION_FLAG}"
 
         # First, handle outputs in snakebids_root or results folder
         try:

--- a/snakebids/utils/utils.py
+++ b/snakebids/utils/utils.py
@@ -50,6 +50,10 @@ class BidsTag(TypedDict):
 BidsTags: TypeAlias = "dict[str, BidsTag]"
 
 
+DEPRECATION_FLAG = "<!DEPRECATED!>"
+"""Sentinel string to mark deprecated config features"""
+
+
 @ft.lru_cache(None)
 def read_bids_tags(bids_json: Path | None = None) -> BidsTags:
     """Read the bids tags we are aware of from a JSON file.


### PR DESCRIPTION
The resolved path was getting overwritten by the args_dict in
SnakebidsArgs. This didn't happen previously because the resolved path
was saved under a different name than the CLI parameter, but since
resolving the names, the CLI parameter name overwrites the resolved
name.

Fix by changing the order of update_config and the manual setting of the
pybids path

Resolves #333 